### PR TITLE
NOJIRA: Reduces amount of unnecessary email notifications

### DIFF
--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -4,7 +4,7 @@
     concurrent: false
     publishers:
       - email:
-          recipients: ci@lists.gpii.net
+          recipients: ops-notifications@lists.inclusivedesign.ca
     # If repository issues are encountered retry the specified number of times 
     retry-count: 5
     logrotate:

--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -22,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-linux-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: create-linux-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -40,7 +40,7 @@
               predefined-parameters: parent_workspace=$WORKSPACE
       - multijob:
           name: delete-linux-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: delete-linux-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -62,7 +62,10 @@
     workspace: $parent_workspace
     builders:
       - shell: grunt unit-tests
-          
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
+
 - job:
     name: linux-acceptance-tests
     description: 'GPII Linux acceptance tests'
@@ -70,7 +73,10 @@
     workspace: $parent_workspace
     builders:
       - shell: grunt acceptance-tests
-        
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
+
 - job:
     name: delete-linux-vm
     description: 'Job responsible for deleting the test VM'

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -23,7 +23,7 @@
       # directory can be used.
       - multijob:
           name: create-nexus-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: create-nexus-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -35,7 +35,7 @@
               predefined-parameters: parent_workspace=$WORKSPACE
       - multijob:
           name: delete-nexus-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: delete-nexus-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -58,6 +58,9 @@
     builders:
       - shell: vagrant ssh -c 'sudo systemctl stop nexus.service'
       - shell: vagrant ssh -c 'node /home/vagrant/sync/tests/all-tests.js'
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
 
 - job:
     name: delete-nexus-vm

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -22,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-universal-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: create-universal-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -46,7 +46,7 @@
               predefined-parameters: parent_workspace=$WORKSPACE
       - multijob:
           name: delete-universal-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: delete-universal-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -71,6 +71,9 @@
           results: report.tap
     builders:
       - shell: vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && DISPLAY=:0 testem ci --file tests/web/testem_qi.json'
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
           
 - job:
     name: universal-node-tests
@@ -79,6 +82,9 @@
     workspace: $parent_workspace
     builders:
       - shell: vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && npm test'
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
 
 - job:
     name: universal-node-production-tests
@@ -87,6 +93,9 @@
     workspace: $parent_workspace
     builders:
       - shell: vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && node tests/ProductionConfigTests.js'
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
 
 - job:
     name: delete-universal-vm

--- a/jenkins_jobs/update-jenkins-job-definitions.yml
+++ b/jenkins_jobs/update-jenkins-job-definitions.yml
@@ -16,5 +16,5 @@
       daysToKeep: 7
     publishers:
       - email:
-          recipients: ci@lists.gpii.net
+          recipients: ops-notifications@lists.inclusivedesign.ca
           

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -22,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-windows-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: create-windows-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -43,7 +43,7 @@
             - name: windows-unit-tests
       - multijob:
           name: delete-windows-vm
-          condition: COMPLETED
+          condition: SUCCESSFUL
           projects:
             - name: delete-windows-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -76,7 +76,10 @@
     workspace: c:\vagrant
     builders:
       - batch: npm install --ignore-scripts=true
-      - batch: grunt build
+      - batch: grunt --force build
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
 
 - job:
     name: windows-acceptance-tests
@@ -85,6 +88,9 @@
     workspace: c:\vagrant
     builders:
       - batch: node tests\AcceptanceTests.js builtIn
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
 
 - job:
     name: windows-unit-tests
@@ -93,6 +99,9 @@
     workspace: c:\vagrant
     builders:
       - batch: node tests\UnitTests.js
+    publishers:
+      - email:
+          recipients: ci@lists.gpii.net
 
 - job:
     name: delete-windows-vm


### PR DESCRIPTION
Certain jobs such as creating or destroying VMs should only notify the ops team when failures occur. GPII project related jobs should send their failure notifications to the ci@lists.gpii.net list. Changing the 'condition' parameter of ops related jobs to 'SUCCESSFUL' means that project related jobs won't be carried out if prior environment related failures occur.
