### PR TITLE
NOJIRA: Removes unnecessary job

### DIFF
--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -70,18 +70,6 @@
       - shell: vagrant winrm -e -c 'psexec \\localhost -accepteula -u vagrant -p vagrant -w "c:\jenkins" -d -i cmd /c start /min java -jar slave.jar -jnlpUrl https://ci-int.gpii.net/computer/gpii-windows-10/slave-agent.jnlp -secret %JENKINS_WIN10_NODE_SECRET% -noCertificateCheck' || true
 
 - job:
-    name: windows-build
-    description: 'GPII Windows unit tests'
-    node: gpii-windows-10
-    workspace: c:\vagrant
-    builders:
-      - batch: npm install --ignore-scripts=true
-      - batch: grunt --force build
-    publishers:
-      - email:
-          recipients: ci@lists.gpii.net
-
-- job:
     name: windows-acceptance-tests
     description: 'GPII Windows acceptance tests'
     node: gpii-windows-10


### PR DESCRIPTION
The GPII build takes place as part of Vagrant provisioning. It doesn't need to be run again after the VM has been created.
