### PR TITLE
NOJIRA: Lowers build timeout limit

### DIFF
--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -12,7 +12,7 @@
     wrappers:
       - timeout:
           # Abort after these many minutes
-          timeout: 40
+          timeout: 25
           # Mark the build as failed
           fail: true
 


### PR DESCRIPTION
Currently it takes 40 minutes for CI jobs to timeout. Lowering this to 25 minutes seems more ideal. 
