### PR TITLE
GPII-1857 - Decrease number of jobs kept to make mirror script faster and Jenkins less sluggish.

### DIFF
--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -8,7 +8,7 @@
     # If repository issues are encountered retry the specified number of times 
     retry-count: 5
     logrotate:
-      daysToKeep: 30
+      daysToKeep: 7
     wrappers:
       - timeout:
           # Abort after these many minutes


### PR DESCRIPTION
Suggesting we decrease the number of jobs kept from 30 days to 7 days. Advantages include:
- Static website mirror will take less time to run, allowing us to increase its frequency from 10min to 5min or less
- Jenkins seems to take a performance hit as the number of jobs increase. This should also help in making it faster (although this is secondary to this PR).

Obvious disadvantage is less historical data about builds.
