### PR TITLE
NOJIRA: Uses uppercase characters for GitHub org's name

### DIFF
--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -11,7 +11,7 @@
       # TODO: Please note that a build failure in one branch will stop the entire
       # job even if other branches need to be built. 
       - git:
-          url: https://github.com/gpii/linux.git
+          url: https://github.com/GPII/linux.git
           branches:
             - master
     triggers:

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -11,7 +11,7 @@
       # TODO: Please note that a build failure in one branch will stop the entire
       # job even if other branches need to be built. 
       - git:
-          url: https://github.com/gpii/universal.git
+          url: https://github.com/GPII/universal.git
           branches:
             - master
     triggers:

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -11,7 +11,7 @@
       # TODO: Please note that a build failure in one branch will stop the entire
       # job even if other branches need to be built.
       - git:
-          url: https://github.com/gpii/windows.git
+          url: https://github.com/GPII/windows.git
           branches:
             - master 
     triggers:


### PR DESCRIPTION
The Jenkins github-plugin seems to be case-sensitive so the GPII repo URLs need these changes
for webhook payload events to trigger jobs.
