### PR TITLE
GPII-1863: Makes use of new CI node

### DIFF
--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -2,7 +2,7 @@
     name: linux-tests
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Linux Framework tests'
     project-type: multijob
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -22,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-linux-vm
-          condition: SUCCESSFUL
+          condition: COMPLETED
           projects:
             - name: create-linux-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -48,17 +48,17 @@
 - job:
     name: create-linux-vm
     description: 'Job responsible for creating a test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       # Setting BUILD_ID for the vagrant process to make sure the Jenkins process tree killer
       # doesn't kill the VM before the next job is started.
-      - shell: BUILD_ID=linux DISPLAY=:0 vagrant up --provider virtualbox
+      - shell: BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox
 
 - job:
     name: linux-unit-tests
     description: 'GPII Linux unit tests'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: grunt unit-tests
@@ -69,7 +69,7 @@
 - job:
     name: linux-acceptance-tests
     description: 'GPII Linux acceptance tests'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: grunt acceptance-tests
@@ -80,7 +80,7 @@
 - job:
     name: delete-linux-vm
     description: 'Job responsible for deleting the test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant destroy -f

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -2,7 +2,7 @@
     name: nexus-tests
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Nexus tests'
     project-type: multijob
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -14,7 +14,6 @@
           url: https://github.com/simonbates/nexus.git
           branches:
             - master
-            - p4a-feb-2016
     triggers:
       - github
     builders:
@@ -23,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-nexus-vm
-          condition: SUCCESSFUL
+          condition: COMPLETED
           projects:
             - name: create-nexus-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -43,21 +42,20 @@
 - job:
     name: create-nexus-vm
     description: 'Job responsible for creating a test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       # Setting BUILD_ID for the vagrant process to make sure the Jenkins process tree killer
       # doesn't kill the VM before the next job is started.
-      - shell: BUILD_ID=nexus vagrant up --provider virtualbox
+      - shell: BUILD_ID=gpii-nexus vagrant up --provider virtualbox
 
 - job:
     name: nexus-unit-tests
     description: 'GPII Nexus unit tests'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: vagrant ssh -c 'sudo systemctl stop nexus.service'
-      - shell: vagrant ssh -c 'node /home/vagrant/sync/tests/all-tests.js'
+      - shell: grunt tests
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -65,7 +63,7 @@
 - job:
     name: delete-nexus-vm
     description: 'Job responsible for deleting the test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant destroy -f

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -2,7 +2,7 @@
     name: universal-tests
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Universal tests'
     project-type: multijob
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -22,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-universal-vm
-          condition: SUCCESSFUL
+          condition: COMPLETED
           projects:
             - name: create-universal-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -54,17 +54,17 @@
 - job:
     name: create-universal-vm
     description: 'Job responsible for creating a test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       # Setting BUILD_ID for the vagrant process to make sure the Jenkins process tree killer
       # doesn't kill the VM before the next job is started.
-      - shell: BUILD_ID=universal DISPLAY=:0 vagrant up --provider virtualbox
+      - shell: BUILD_ID=gpii-universal DISPLAY=:0 vagrant up --provider virtualbox
 
 - job:
     name: universal-browser-tests
     description: 'GPII Universal browser tests'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && DISPLAY=:0 testem ci --file tests/web/testem_qi.json'
@@ -77,7 +77,7 @@
 - job:
     name: universal-node-tests
     description: 'GPII Universal node-based tests'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && npm test'
@@ -88,7 +88,7 @@
 - job:
     name: universal-node-production-tests
     description: 'GPII Universal node-based production tests'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && node tests/ProductionConfigTests.js'
@@ -99,7 +99,7 @@
 - job:
     name: delete-universal-vm
     description: 'Job responsible for deleting the test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant destroy -f

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -2,7 +2,7 @@
     name: windows-tests
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Windows tests'
     project-type: multijob
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -22,7 +22,7 @@
       # directory can be used.
       - multijob:
           name: create-windows-vm
-          condition: SUCCESSFUL
+          condition: COMPLETED
           projects:
             - name: create-windows-vm
               predefined-parameters: parent_workspace=$WORKSPACE
@@ -51,12 +51,12 @@
 - job:
     name: create-windows-vm
     description: 'Job responsible for creating a test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       # Setting BUILD_ID for vagrant to make sure Jenkins process tree killer doesn't kill the VM
       # before the next job is started
-      - shell: DISPLAY=:0 BUILD_ID=vmShouldPersist vagrant up --provider virtualbox
+      - shell: DISPLAY=:0 BUILD_ID=gpii-windows vagrant up --provider virtualbox
       - shell: vagrant winrm -e -c 'cmd /c mkdir c:\jenkins'
       - shell: vagrant winrm -e -c 'cmd /c curl -ks -o c:\jenkins\slave.jar https://ci-int.gpii.net/jnlpJars/slave.jar'
       # Set a JENKINS_WIN10_NODE_SECRET variable so that the Jenkins node secret is available in
@@ -94,7 +94,7 @@
 - job:
     name: delete-windows-vm
     description: 'Job responsible for deleting the test VM'
-    node: h-0007.tor1.inclusivedesign.ca
+    node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
       - shell: vagrant destroy -f


### PR DESCRIPTION
Makes the new CI node the default and addresses some Vagrant inconsistencies. 
