### PR TITLE
GPII-1822: Makes Jenkins run CI jobs for PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pull requests sent by user accounts whitelisted in the [defaults.yml](https://gi
 
 ### How to Avoid Triggering a Job
 
-If you would like to avoid triggering a job please type the following text in your PR comment:
+If you would like to avoid triggering a job please include the following text in your PR comment:
 
 ```
 [skip ci]
@@ -27,7 +27,7 @@ If you would like to avoid triggering a job please type the following text in yo
 
 ### How to Manually Trigger a Job
 
-If an unrecognized account is used to send a PR then the CI server will post a comment for that PR asking an administrator to verify changes and trigger the job. You can trigger jobs by posting the following comment:
+If an unrecognized account is used to send a PR then the CI server will post a comment for that PR asking an administrator to verify changes and trigger the job. An administrator can trigger jobs by posting the following comment:
 
 ```
 ok to test

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 The [GPII Continuous Integration server](https://ci.gpii.net/) uses [Jenkins Job Builder](http://docs.openstack.org/infra/jenkins-job-builder) definitions located in the ``jenkins_jobs`` directory of this repository to generate its configuration. This allows CI server jobs to be maintained transparently using version control instead of having to rely on the Jenkins UI. 
 
-The CI server is deployed on a CentOS VM. It delegates the majority of job tasks to physical Linux hosts so that job performance issues don't affect the Jenkins process and also because certain jobs require VMs that can provide windowing environments. Two exceptions are the ``update-jenkins-interface`` and ``update-jenkins-job-definitions`` jobs which run on the CI server itself. These jobs should not be removed.
+The CI server is deployed on a CentOS VM. It delegates the majority of job tasks to physical hosts so that job performance issues don't affect the Jenkins process and also because certain jobs require VMs that can provide windowing environments. One exception is the ``update-jenkins-job-definitions`` job which runs on the CI server itself. This job should not be removed.
 
-For security reasons an Nginx host sits in front of the CI server and creates a read-only archive of its UI using the ``update-jenkins-interface`` job. The contents of this archive are served when the https://ci.gpii.net URL is visited. The CI server itself can only be reached by a limited number of hosts.
+For security reasons an Nginx host sits in front of the CI server and creates a read-only archive of its UI. The contents of this archive are served when the https://ci.gpii.net URL is visited. The CI server itself can only be reached by a limited number of hosts.
 
 The remaining definitions in the ``jenkins_jobs`` directory are what the GPII build jobs use:
 
@@ -13,4 +13,24 @@ The remaining definitions in the ``jenkins_jobs`` directory are what the GPII bu
 * ``universal.yml`` - job defintion for the [GPII Universal](https://github.com/gpii/universal/) project
 * ``windows.yml`` - job defintion for the [GPII Windows Framework](https://github.com/gpii/windows/) project
 
-Commits in the GPII project repositories listed above will trigger builds in the CI environment using GitHub webhooks.
+## Triggering CI Jobs
+
+Pull requests sent by user accounts whitelisted in the [defaults.yml](https://github.com/GPII/ci-service/blob/master/jenkins_jobs/defaults.yml) file will trigger builds in the CI environment using the [GitHub Pull Request Builder plugin](http://docs.openstack.org/infra/jenkins-job-builder/triggers.html#triggers.github-pull-request). The CI server checks for PR changes every five minutes.
+
+### How to Avoid Triggering a Job
+
+If you would like to avoid triggering a job please type the following text in your PR comment:
+
+```
+[skip ci]
+```
+
+### How to Manually Trigger a Job
+
+If an unrecognized account is used to send a PR then the CI server will post a comment for that PR asking an administrator to verify changes and trigger the job. You can trigger jobs by posting the following comment:
+
+```
+ok to test
+```
+
+A list of administrators named ``admin-list`` is maintained in the [defaults.yml](https://github.com/GPII/ci-service/blob/master/jenkins_jobs/defaults.yml) file. 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ ok to test
 ```
 
 A list of administrators named ``admin-list`` is maintained in the [defaults.yml](https://github.com/GPII/ci-service/blob/master/jenkins_jobs/defaults.yml) file. 
+
+### GitHub Account Used by CI Server
+
+The CI server uses the [gpii-bot](https://github.com/gpii-bot) account to post PR comments. It has to be added as a collaborator to every repository that needs to be integrated with the CI service.

--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -20,21 +20,22 @@
           # List of admins who can trigger jobs for PRs opened by unrecognized users.
           admin-list:
             - amb26
+            - cindyli            
             - colinbdclark
             - javihernandez
             - kaspermarkus
+            - simonbates
             - sgithens
+            - yzen
           # Whitelist the following users so that their PRs automatically trigger jobs. 
           white-list:
             - amatas
             - avtar
             - bsheytanov
-            - cindyli
             - gloob
             - gtirloni
             - localduke
             - michelled
-            - simonbates
             - SteveALee
             - Thanos21
             - the-t-in-rtf

--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -5,7 +5,7 @@
     publishers:
       - email:
           recipients: ops-notifications@lists.inclusivedesign.ca
-    # If repository issues are encountered retry the specified number of times 
+    # If repository issues are encountered retry the specified number of times. 
     retry-count: 5
     logrotate:
       daysToKeep: 7
@@ -15,4 +15,34 @@
           timeout: 25
           # Mark the build as failed
           fail: true
-
+    triggers:
+      - github-pull-request:
+          # List of admins who can trigger jobs for PRs opened by unrecognized users.
+          admin-list:
+            - amb26
+            - colinbdclark
+            - javihernandez
+            - kaspermarkus
+            - sgithens
+          # Whitelist the following users so that their PRs automatically trigger jobs. 
+          white-list:
+            - amatas
+            - avtar
+            - bsheytanov
+            - cindyli
+            - gloob
+            - gtirloni
+            - localduke
+            - michelled
+            - simonbates
+            - SteveALee
+            - Thanos21
+            - the-t-in-rtf
+            - triffon
+            - waharnum
+          # Poll GitHub every five minutes.
+          cron: '*/5 * * * *'
+          build-desc-template: 'Triggered by PR'
+          success-comment: 'CI job passed.'
+          failure-comment: 'CI job failed. Please visit http://lists.gpii.net/pipermail/ci/ for more details.'
+          error-comment: 'CI job error. Please visit http://lists.gpii.net/pipermail/ci/ for more details.'

--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -3,6 +3,10 @@
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Linux Framework tests'
     project-type: multijob
     node: h-0005.tor1.inclusivedesign.ca
+    properties:
+      # Required by the GitHub PR builder plugin.
+      - github:
+          url: https://github.com/GPII/linux/
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -14,8 +18,6 @@
           url: https://github.com/GPII/linux.git
           branches:
             - master
-    triggers:
-      - github
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -3,6 +3,10 @@
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Nexus tests'
     project-type: multijob
     node: h-0005.tor1.inclusivedesign.ca
+    properties:
+      # Required by the GitHub PR builder plugin.
+      - github:
+          url: https://github.com/simonbates/nexus/
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -14,8 +18,6 @@
           url: https://github.com/simonbates/nexus.git
           branches:
             - master
-    triggers:
-      - github
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -3,6 +3,10 @@
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Universal tests'
     project-type: multijob
     node: h-0005.tor1.inclusivedesign.ca
+    properties:
+      # Required by the GitHub PR builder plugin.
+      - github:
+          url: https://github.com/GPII/universal/
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -14,8 +18,6 @@
           url: https://github.com/GPII/universal.git
           branches:
             - master
-    triggers:
-      - github
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -3,6 +3,10 @@
     description: 'Main Jenkins job responsible for orchestrating tasks required to run GPII Windows tests'
     project-type: multijob
     node: h-0005.tor1.inclusivedesign.ca
+    properties:
+      # Required by the GitHub PR builder plugin.
+      - github:
+          url: https://github.com/GPII/windows/
     scm:
       # Before making changes to the Git repository URL and/or branch(es) please
       # make sure that a Vagrantfile and other content required to provision test
@@ -14,8 +18,6 @@
           url: https://github.com/GPII/windows.git
           branches:
             - master 
-    triggers:
-      - github
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working


### PR DESCRIPTION
These changes make Jenkins trigger CI jobs whenever a PR is sent to monitored repositories. Every repository that wants to make use of this service needs to add the [gpii-bot](https://github.com/gpii-bot) account as a collaborator.
