### PR TITLE
GPII-1822: Makes the GitHub PR Builder plugin only use a PR author's …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ The [GPII Continuous Integration server](https://ci.gpii.net/) uses [Jenkins Job
 
 The CI server is deployed on a CentOS VM. It delegates the majority of job tasks to physical hosts so that job performance issues don't affect the Jenkins process and also because certain jobs require VMs that can provide windowing environments. One exception is the ``update-jenkins-job-definitions`` job which runs on the CI server itself. This job should not be removed.
 
-For security reasons an Nginx host sits in front of the CI server and creates a read-only archive of its UI. The contents of this archive are served when the https://ci.gpii.net URL is visited. The CI server itself can only be reached by a limited number of hosts.
-
 The remaining definitions in the ``jenkins_jobs`` directory are what the GPII build jobs use:
 
 * ``defaults.yml`` - default values used by multiple jobs
@@ -13,7 +11,7 @@ The remaining definitions in the ``jenkins_jobs`` directory are what the GPII bu
 * ``universal.yml`` - job defintion for the [GPII Universal](https://github.com/gpii/universal/) project
 * ``windows.yml`` - job defintion for the [GPII Windows Framework](https://github.com/gpii/windows/) project
 
-## Triggering CI Jobs
+## How CI Jobs Get Triggered
 
 Pull requests sent by user accounts whitelisted in the [macros.yml](https://github.com/GPII/ci-service/blob/master/jenkins_jobs/macros.yml) file will trigger builds in the CI environment using the [GitHub Pull Request Builder plugin](http://docs.openstack.org/infra/jenkins-job-builder/triggers.html#triggers.github-pull-request). The CI server checks for PR changes every five minutes.
 
@@ -35,6 +33,6 @@ ok to test
 
 A list of administrators named ``admin-list`` is maintained in the [macros.yml](https://github.com/GPII/ci-service/blob/master/jenkins_jobs/macros.yml) file. 
 
-### GitHub Account Used by CI Server
+## How Can Repositories Use This Service?  
 
-The CI server uses the [gpii-bot](https://github.com/gpii-bot) account to post PR comments. It has to be added as a collaborator to every repository that needs to be integrated with the CI service.
+The CI server uses the [gpii-bot](https://github.com/gpii-bot) account to post PR comments. It has to be added as a collaborator, [with push access](https://developer.github.com/v3/repos/statuses/#create-a-status), to every repository that needs to be integrated with the CI service.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The remaining definitions in the ``jenkins_jobs`` directory are what the GPII bu
 
 Pull requests sent by user accounts whitelisted in the [macros.yml](https://github.com/GPII/ci-service/blob/master/jenkins_jobs/macros.yml) file will trigger builds in the CI environment using the [GitHub Pull Request Builder plugin](http://docs.openstack.org/infra/jenkins-job-builder/triggers.html#triggers.github-pull-request). The CI server checks for PR changes every five minutes.
 
+Triggered CI jobs report their results as PR comments. Results will usually state whether a job passed or failed.
+
 ### How to Avoid Triggering a Job
 
 If you would like to avoid triggering a job please include the following text in your PR comment:

--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -10,16 +10,7 @@
     triggers:
       - gh-pr-builder
     scm:
-      # Before making changes to the Git repository URL and/or branch(es) please
-      # make sure that a Vagrantfile and other content required to provision test
-      # VMs is available.
-      #
-      # TODO: Please note that a build failure in one branch will stop the entire
-      # job even if other branches need to be built. 
-      - git:
-          url: https://github.com/GPII/linux.git
-          branches:
-            - master
+      - gh-pr-scm
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working

--- a/jenkins_jobs/macros.yml
+++ b/jenkins_jobs/macros.yml
@@ -34,3 +34,15 @@
           success-comment: 'CI job passed.'
           failure-comment: 'CI job failed. Please visit http://lists.gpii.net/pipermail/ci/ for more details.'
           error-comment: 'CI job error. Please visit http://lists.gpii.net/pipermail/ci/ for more details.'
+
+# The gh-pr-scm macro should be used alongside gh-pr-builder. It will only checkout the PR 
+# contributor's repository and branch. This changes the default behaviour of the plugin 
+# which attempts to merge changes with a base branch ('master' in our case). This is a 
+# workaround for the following issue: https://issues.jenkins-ci.org/browse/JENKINS-35170
+- scm:
+    name: gh-pr-scm
+    scm:
+      - git:
+          url: ${ghprbAuthorRepoGitUrl}
+          branches:
+            - ${ghprbActualCommit}

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -10,16 +10,7 @@
     triggers:
       - gh-pr-builder
     scm:
-      # Before making changes to the Git repository URL and/or branch(es) please
-      # make sure that a Vagrantfile and other content required to provision test
-      # VMs is available.
-      #
-      # TODO: Please note that a build failure in one branch will stop the entire
-      # job even if other branches need to be built.
-      - git:
-          url: https://github.com/GPII/nexus.git
-          branches:
-            - master
+      - gh-pr-scm
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -10,16 +10,7 @@
     triggers:
       - gh-pr-builder
     scm:
-      # Before making changes to the Git repository URL and/or branch(es) please
-      # make sure that a Vagrantfile and other content required to provision test
-      # VMs is available.
-      #
-      # TODO: Please note that a build failure in one branch will stop the entire
-      # job even if other branches need to be built. 
-      - git:
-          url: https://github.com/GPII/universal.git
-          branches:
-            - master
+      - gh-pr-scm
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -10,16 +10,7 @@
     triggers:
       - gh-pr-builder
     scm:
-      # Before making changes to the Git repository URL and/or branch(es) please
-      # make sure that a Vagrantfile and other content required to provision test
-      # VMs is available.
-      #
-      # TODO: Please note that a build failure in one branch will stop the entire
-      # job even if other branches need to be built.
-      - git:
-          url: https://github.com/GPII/windows.git
-          branches:
-            - master 
+      - gh-pr-scm
     builders:
       # Each parent multijob builder passes the Jenkins WORKSPACE environment
       # variable to its child job as a parameter so that a common Git working


### PR DESCRIPTION
…repo and branch

Makes the GitHub PR Builder plugin only use the PR contributor's repository and branch, and not merge changes in a base branch ('master' in our case). This is a workaround for the following issue:

https://issues.jenkins-ci.org/browse/JENKINS-35170
