### PR TITLE
GPII-1989 - Jenkins should keep builds longer

### DIFF
--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -8,7 +8,7 @@
     # If repository issues are encountered retry the specified number of times. 
     retry-count: 5
     logrotate:
-      daysToKeep: 7
+      daysToKeep: 180
     wrappers:
       - timeout:
           # Abort after these many minutes


### PR DESCRIPTION
Increasing from 7 days to 180 days. Will re-evaluate Jenkins performance in 4-5 months to decide if it should be decrease or increased. Ideally, it would be useful to keep all builds ever done.
