### PR TITLE
Allow people responsible for CI platform to trigger builds

### DIFF
--- a/jenkins_jobs/macros.yml
+++ b/jenkins_jobs/macros.yml
@@ -5,9 +5,12 @@
       - github-pull-request:
           # List of admins who can trigger jobs for PRs opened by unrecognized users.
           admin-list:
+            - amatas
             - amb26
+            - avtar
             - cindyli            
             - colinbdclark
+            - gtirloni
             - javihernandez
             - kaspermarkus
             - simonbates


### PR DESCRIPTION
It's a PITA to have to manually add ourselves to Jenkins jobs just so we can come back to GitHub and add 'ok to test' to PR's every time we are asked to investigate something.

This adds Alfredo, Avtar and Giovanni and admins so they can trigger jobs as they please (otherwise they can only trigger their own PRs).