### PR TITLE
Use internal winrm plugin of Vagrant instead of external one

### DIFF
--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -56,7 +56,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: vagrant winrm -c "do.ps1 -c 'node tests\UnitTests.js'"
+      - shell: vagrant ssh -- "powershell -c 'do.ps1 -c '\''node tests\UnitTests.js'\'''"
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -67,7 +67,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: vagrant winrm -c "do.ps1 -c 'node tests\AcceptanceTests.js builtIn'"
+      - shell: vagrant ssh -- "powershell -c 'do.ps1 -c '\''node tests\AcceptanceTests.js builtIn'\'''"
     publishers:
       - email:
           recipients: ci@lists.gpii.net


### PR DESCRIPTION
Vagrant supports winrm communicator without using an external plugin:
https://github.com/mitchellh/vagrant/tree/master/plugins/communicators/winrm

With these changes we can launch the tests using the Vagrant internals, getting rid of the vagrant-winrm plugin.

_I tried to simplify the quotes without success_