### PR TITLE
Fix the indentation of url parameter

### DIFF
--- a/jenkins_jobs/gpii-app.yml
+++ b/jenkins_jobs/gpii-app.yml
@@ -6,7 +6,7 @@
     properties:
       # Required by the GitHub PR builder plugin.
       - github:
-        url: https://github.com/GPII/gpii-app
+          url: https://github.com/GPII/gpii-app/
     triggers:
       - gh-pr-builder
     scm:


### PR DESCRIPTION
The `url` parameter wasn't indented