### PR TITLE
Disable notifications to ops-notifications

### DIFF
--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -2,9 +2,6 @@
     name: global
     project-type: freestyle
     concurrent: false
-    publishers:
-      - email:
-          recipients: ops-notifications@lists.inclusivedesign.ca
     # If repository issues are encountered retry the specified number of times. 
     retry-count: 5
     logrotate:


### PR DESCRIPTION
@avtar @amatas @mrtyler I've a feeling nobody is actually reading these notifications so I would like to disable them. Developers get notified if a build fails on ci@lists.gpii.net and they can contact us if they think the failure reason is not related to their code.
