### PR TITLE
Migrate GPII jobs from ci.inclusivedesign.ca

### DIFF
--- a/jenkins_jobs/ansible-roles.yml
+++ b/jenkins_jobs/ansible-roles.yml
@@ -1,0 +1,67 @@
+- project:
+    name: ansible-roles
+    jobs:
+        - '{role}':
+            role: ansible-ansible
+        - '{role}':
+            role: ansible-collectd
+        - '{role}':
+            role: ansible-grafana
+        - '{role}':
+            role: ansible-gpii-ci-worker
+        - '{role}':
+            role: ansible-gpii-version-updater
+        - '{role}':
+            role: ansible-influxdb
+        - '{role}':
+            role: ansible-nginx-common
+        - '{role}':
+            role: ansible-prometheus-tests
+
+- job-template:
+    name: '{role}'
+    project-type: 'freestyle'
+    scm:
+        - git:
+            url: 'https://github.com/idi-ops/{role}.git'
+            skip-tag: true
+            branches:
+                - master
+    triggers:
+        - github
+        - pollscm:
+            cron: "H/5 * * * *"
+        - timed: '@daily'
+
+    node: h-0005.tor1.inclusivedesign.ca
+    builders:
+        # Several things going on here:
+        #
+        # - The pip provided by CentOS 7 via python-virtualenv has trouble
+        # installing things (see
+        # https://github.com/pypa/setuptools/issues/937). We need an upgraded
+        # pip *before* we can install the other requirements, so we do that as
+        # its own step. We nudge it up from the CentOS 7 default to be
+        # minimally opinionated about which version gets installed.
+        #
+        # - /tmp on Jenkins node h-0005.tor1.inclusivedesign.ca is mounted
+        # noexec, which prevents pycyrpto (in requirements.txt) from running
+        # autoconf (see https://bugs.launchpad.net/pycrypto/+bug/1294670). So
+        # we make a local tmpdir and use it when installing from
+        # requirements.txt.
+        #
+        # - This is a dubious amount of work to do in a build one-liner. I
+        # considered moving to Tox but decided to stop here. If you are
+        # thinking of adding more steps here, please consider instead moving to
+        # Tox (or a Makefile or a shell script or something).
+        - shell: >
+            virtualenv venv &&
+            . venv/bin/activate &&
+            pip install "pip > 1.4.1" &&
+            mkdir -p pip-tmp &&
+            TMPDIR=pip-tmp pip install -r requirements.txt &&
+            molecule --debug test
+
+    publishers:
+      - email:
+            recipients: ops-notifications@lists.inclusivedesign.ca

--- a/jenkins_jobs/container-gpii-production.yml
+++ b/jenkins_jobs/container-gpii-production.yml
@@ -1,0 +1,161 @@
+# Ansible plugin cannot be used used until this bug is fixed:
+# https://issues.jenkins-ci.org/browse/JENKINS-32384
+
+- defaults:
+    name: gpii-production
+    jenkins_node: master
+    ssh_credential: aa656fd8-6d2f-416f-ab65-9dc1876d1149
+
+- project:
+    name: gpii-production
+    jenkins_tag: production
+    ansible_inventory: prd
+    ansible_host_pattern: tor1_gpii_ci_docker
+    ansible_playbook: deploy_containers_gpii_prd.yml
+    jobs:
+      - container-gpii-production-all
+
+- job-group:
+    name: container-gpii-production-all
+    jobs:
+      - 'container-gpii-production'
+      - 'container-gpii-production-couchdb'
+      - 'container-gpii-production-preferences-dataloader'
+      - 'container-gpii-production-preferences-server'
+      - 'container-gpii-production-flow-manager'
+      - 'container-gpii-production-qi-dashboard-backend'
+      - 'container-gpii-production-qi-dashboard-frontend'
+
+- wrapper:
+    name: deploy_credentials_production
+    wrappers:
+      - ssh-agent-credentials:
+          users:
+            - aa656fd8-6d2f-416f-ab65-9dc1876d1149
+
+- job-template:
+    name: 'container-gpii-production'
+    project-type: 'multijob'
+    defaults: gpii-production
+    concurrent: false
+    node: '{jenkins_node}'
+    publishers:
+      - email:
+            recipients: gpii-infra-notifications@lists.gpii.net
+    scm:
+        - git:
+            url: git@github.com:inclusive-design/ops-shared.git
+            credentials-id: 5393cf30-f707-473a-9642-e1c46128f20a
+            skip-tag: true
+            submodule:
+              recursive: true
+            branches:
+                - master
+    builders:
+      - multijob:
+          name: Database
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-production-couchdb'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: Data load
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-production-preferences-dataloader'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: Preferences Server
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-production-preferences-server'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: Flow Manager
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-production-flow-manager'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: QI Dashboard Backend
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-production-qi-dashboard-backend'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: QI Dashboard Frontend
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-production-qi-dashboard-frontend'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+- job-template:
+    name: 'container-gpii-production-couchdb'
+    description: Deploy CouchDB container'
+    defaults: gpii-production
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_production
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-couchdb {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-production-preferences-dataloader'
+    description: Load preferences data
+    defaults: gpii-production
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_production
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-dataloader {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-production-preferences-server'
+    description: Deploy Preferences Server container
+    defaults: gpii-production
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_production
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-prefserver {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-production-flow-manager'
+    description: Deploy Flow Manager container
+    defaults: gpii-production
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_production
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-flowmanager {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-production-qi-dashboard-backend'
+    description: Deploy QI Dashboard Backend
+    defaults: gpii-production
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_production
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-qi-dashboard-backend {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-production-qi-dashboard-frontend'
+    description: Deploy QI Dashboard Frontend
+    defaults: gpii-production
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_production
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-qi-dashboard-frontend {ansible_playbook}'

--- a/jenkins_jobs/container-gpii-staging.yml
+++ b/jenkins_jobs/container-gpii-staging.yml
@@ -1,0 +1,171 @@
+# Ansible plugin cannot be used used until this bug is fixed:
+# https://issues.jenkins-ci.org/browse/JENKINS-32384
+
+- defaults:
+    name: gpii-staging
+    jenkins_node: master
+    ssh_credential: aa656fd8-6d2f-416f-ab65-9dc1876d1149
+
+- project:
+    name: gpii-staging
+    jenkins_tag: staging
+    ansible_inventory: stg
+    ansible_host_pattern: tor1_gpii_ci_docker
+    ansible_playbook: deploy_containers_gpii_stg.yml
+    jobs:
+      - container-gpii-staging-all
+
+- job-group:
+    name: container-gpii-staging-all
+    jobs:
+      - 'container-gpii-staging'
+      - 'container-gpii-staging-couchdb'
+      - 'container-gpii-staging-preferences-dataloader'
+      - 'container-gpii-staging-preferences-server'
+      - 'container-gpii-staging-flow-manager'
+      - 'container-gpii-staging-qi-dashboard-backend'
+      - 'container-gpii-staging-qi-dashboard-frontend'
+
+- wrapper:
+    name: deploy_credentials_staging
+    wrappers:
+      - ssh-agent-credentials:
+          users:
+            - aa656fd8-6d2f-416f-ab65-9dc1876d1149
+
+- job-template:
+    name: 'container-gpii-staging'
+    project-type: 'multijob'
+    defaults: gpii-staging
+    concurrent: false
+    node: '{jenkins_node}'
+    publishers:
+      - email:
+            recipients: gpii-infra-notifications@lists.gpii.net
+    triggers:
+      - reverse:
+          result: success
+          jobs:
+            - docker-idi-couchdb-latest
+            - docker-gpii-preferences-dataloader-master
+            - docker-gpii-preferences-server-master
+            - docker-gpii-flow-manager-master
+            - docker-gpii-qi-dashboard-backend-master
+            - docker-gpii-qi-dashboard-frontend-GPII-2204
+    scm:
+        - git:
+            url: git@github.com:inclusive-design/ops-shared.git
+            credentials-id: 5393cf30-f707-473a-9642-e1c46128f20a
+            skip-tag: true
+            submodule:
+              recursive: true
+            branches:
+                - master
+    builders:
+      - multijob:
+          name: Database
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-staging-couchdb'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: Data load
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-staging-preferences-dataloader'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: Preferences Server
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-staging-preferences-server'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: Flow Manager
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-staging-flow-manager'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: QI Dashboard Backend
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-staging-qi-dashboard-backend'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+      - multijob:
+          name: QI Dashboard Frontend
+          condition: SUCCESSFUL
+          projects:
+            - name: 'container-gpii-staging-qi-dashboard-frontend'
+              predefined-parameters: parent_workspace=$WORKSPACE/ansible
+
+- job-template:
+    name: 'container-gpii-staging-couchdb'
+    description: Deploy CouchDB container'
+    defaults: gpii-staging
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_staging
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-couchdb {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-staging-preferences-dataloader'
+    description: Load preferences data
+    defaults: gpii-staging
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_staging
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-dataloader {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-staging-preferences-server'
+    description: Deploy Preferences Server container
+    defaults: gpii-staging
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_staging
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-prefserver {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-staging-flow-manager'
+    description: Deploy Flow Manager container
+    defaults: gpii-staging
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_staging
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-flowmanager {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-staging-qi-dashboard-backend'
+    description: Deploy QI Dashboard Backend container
+    defaults: gpii-staging
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_staging
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-qi-dashboard-backend {ansible_playbook}'
+
+- job-template:
+    name: 'container-gpii-staging-qi-dashboard-frontend'
+    description: Deploy QI Dashboard Frontend container
+    defaults: gpii-staging
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - deploy_credentials_staging
+    builders:
+      - shell: '/usr/bin/ansible-playbook -i inventory/{ansible_inventory} -l {ansible_host_pattern} -t container-qi-dashboard-frontend {ansible_playbook}'

--- a/jenkins_jobs/defaults.yml
+++ b/jenkins_jobs/defaults.yml
@@ -4,6 +4,7 @@
     concurrent: false
     # If repository issues are encountered retry the specified number of times. 
     retry-count: 5
+    build_timeout: 45
     logrotate:
       daysToKeep: 180
     wrappers:

--- a/jenkins_jobs/docker-gpii-first-discovery-server.yml
+++ b/jenkins_jobs/docker-gpii-first-discovery-server.yml
@@ -1,0 +1,172 @@
+---
+# These jobs will build the GPII/first-discovery-server Docker image.
+#
+# The variables git_*_{repo,branch} allow for the flexibility to pick
+# and match the branches are necessary. Ideally, they should be equal
+# but we are not enforcing this here in case some odd situation shows
+# up and we need to break away from that convention.
+#
+# A similar situation happens with the docker_tag variable.
+#
+# It should be noted that the version of Node.js being used in each
+# project is really defined in the Dockerfile (FROM). The goal of
+# specifying it here as well is because we need this information at
+# configuration time to know which Jenkins job we should be downstream
+# to.
+#
+# Before each build, a cleanup runs to remove the previously created
+# layer so avoid working with stale data. This is necessary during
+# code changes otherwise Docker will be happy with the existing
+# layer that matches the string statement from the Dockerfile. This
+# is useful for lowers layers (e.g. CentOS and Node.js) so we don't
+# have to rebuild, but it creates a problem here. We still taking
+# advantage of not having to rebuild lower layers, but rebuilding
+# our layers is unavoidable.
+#
+# Finally, you should create a new project node for each version
+# that should be built.
+
+- defaults:
+    name: gpii-first-discovery-server
+    git_app_repo: https://github.com/GPII/first-discovery-server
+    git_app_branch: master
+    git_docker_repo: https://github.com/GPII/first-discovery-server
+    git_docker_branch: master
+    nodejs_version: 4.4.4
+    docker_username: gpii
+    docker_image: first-discovery-server
+    docker_tag: latest
+    build_timeout: 30
+    email_recipient: gpii-infra-notifications@lists.gpii.net
+    jenkins_node: i-0027.tor1.inclusivedesign.ca
+
+- project:
+    name: gpii-first-discovery-server-master
+    jenkins_tag: master
+    git_app_branch: master
+    git_docker_branch: master
+    nodejs_version: 0.10.45
+    docker_tag: latest
+    jobs:
+      - 'docker-gpii-first-discovery-server-all'
+
+# WARNING: Be careful changing anything below.
+
+# Used to ensure only one `docker push` command runs at a time
+- wrapper:
+    name: gpii-first-discovery-server-docker-push
+    wrappers:
+      - exclusion:
+          resources:
+            - 'gpii-first-discovery-server-docker-push'
+
+- job-group:
+    name: 'docker-gpii-first-discovery-server-all'
+    jobs:
+      - 'docker-gpii-first-discovery-server-{jenkins_tag}'
+      - 'docker-gpii-first-discovery-server-{jenkins_tag}-build'
+#      - 'docker-gpii-first-discovery-server-{jenkins_tag}-test'
+      - 'docker-gpii-first-discovery-server-{jenkins_tag}-release'
+      - 'docker-gpii-first-discovery-server-{jenkins_tag}-cleanup'
+
+- job-template:
+    defaults: gpii-first-discovery-server
+    name: 'docker-gpii-first-discovery-server-{jenkins_tag}'
+    description: 'Builds, tests and pushes the GPII First Discovery Server image'
+    project-type: multijob
+    concurrent: false
+    node: '{jenkins_node}'
+    wrappers:
+      - timeout:
+          timeout: '{build_timeout}'
+          abort: yes
+    publishers:
+      - email:
+            recipients: '{email_recipient}'
+    scm:
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: docker
+          url: '{git_docker_repo}'
+          branches:
+            - '{git_docker_branch}'
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: app
+          url: '{git_app_repo}'
+          branches:
+            - '{git_app_branch}'
+    triggers:
+      - github
+      - reverse:
+          jobs: 'docker-idi-nodejs-{nodejs_version}'
+          result: success
+    builders:
+      - multijob:
+          name: Cleanup
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-first-discovery-server-{jenkins_tag}-cleanup
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Build
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-first-discovery-server-{jenkins_tag}-build
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+#      - multijob:
+#          name: Test
+#          condition: SUCCESSFUL
+#          projects:
+#            - name: docker-gpii-first-discovery-server-{jenkins_tag}-test
+#              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Release
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-first-discovery-server-{jenkins_tag}-release
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+
+- job-template:
+    defaults: gpii-first-discovery-server
+    name: 'docker-gpii-first-discovery-server-{jenkins_tag}-cleanup'
+    description: 'Removes build artifacts'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+
+- job-template:
+    defaults: gpii-first-discovery-server
+    name: 'docker-gpii-first-discovery-server-{jenkins_tag}-build'
+    description: 'Builds Docker image'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker build --pull -t {docker_username}/{docker_image}:{docker_tag} .
+
+#- job-template:
+#    defaults: gpii-first-discovery-server
+#    name: 'docker-gpii-first-discovery-server-{jenkins_tag}-test'
+#    description: 'Runs a test container'
+#    node: '{jenkins_node}'
+#    workspace: $parent_workspace
+#    builders:
+#      - shell: docker run --rm --entrypoint=/bin/bash -i {docker_username}/{docker_image}:{docker_tag} node --eval "console.log('OK');"
+
+# Tag operation is forced in case they've happened in the past from a previous build (no-op)
+# Push is forced otherwise a prompt is displayed asking if really want to publish to public registry
+- job-template:
+    defaults: gpii-first-discovery-server
+    name: 'docker-gpii-first-discovery-server-{jenkins_tag}-release'
+    description: 'Publishes to Docker Hub'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - gpii-first-discovery-server-docker-push
+    builders:
+      - critical-block-start
+      - shell: docker push {docker_username}/{docker_image}:{docker_tag}
+      - critical-block-end

--- a/jenkins_jobs/docker-gpii-preferences-dataloader.yml
+++ b/jenkins_jobs/docker-gpii-preferences-dataloader.yml
@@ -1,0 +1,155 @@
+---
+# These jobs will build the GPII/preferences-dataloader Docker image.
+#
+# The variables git_*_{repo,branch} allow for the flexibility to pick
+# and match the branches are necessary. Ideally, they should be equal
+# but we are not enforcing this here in case some odd situation shows
+# up and we need to break away from that convention.
+#
+# A similar situation happens with the docker_tag variable.
+#
+# It should be noted that the version of Node.js being used in each
+# project is really defined in the Dockerfile (FROM). The goal of
+# specifying it here as well is because we need this information at
+# configuration time to know which Jenkins job we should be downstream
+# to.
+#
+# Before each build, a cleanup runs to remove the previously created
+# layer so avoid working with stale data. This is necessary during
+# code changes otherwise Docker will be happy with the existing
+# layer that matches the string statement from the Dockerfile. This
+# is useful for lowers layers (e.g. CentOS and Node.js) so we don't
+# have to rebuild, but it creates a problem here. We still taking
+# advantage of not having to rebuild lower layers, but rebuilding
+# our layers is unavoidable.
+#
+# Finally, you should create a new project node for each version
+# that should be built.
+
+- defaults:
+    name: gpii-preferences-dataloader
+
+    git_app_repo: https://github.com/GPII/universal.git
+    git_app_branch: master
+
+    git_docker_repo: https://github.com/gpii-ops/docker-preferences-dataloader.git
+    git_docker_branch: master
+    docker_username: gpii
+    docker_image: preferences-dataloader
+    docker_tag: latest
+
+    build_timeout: 30
+    email_recipient: gpii-infra-notifications@lists.gpii.net
+    jenkins_node: i-0027.tor1.inclusivedesign.ca
+
+- project:
+    name: gpii-preferences-dataloader-master
+    jenkins_tag: master
+    git_app_branch: master
+    git_docker_branch: master
+    docker_tag: latest
+    jobs:
+      - 'docker-gpii-preferences-dataloader-all'
+
+# WARNING: Be careful changing anything below.
+
+# Used to ensure only one `docker push` command runs at a time
+- wrapper:
+    name: gpii-preferences-dataloader-docker-push
+    wrappers:
+      - exclusion:
+          resources:
+            - 'gpii-preferences-dataloader-docker-push'
+
+- job-group:
+    name: 'docker-gpii-preferences-dataloader-all'
+    jobs:
+      - 'docker-gpii-preferences-dataloader-{jenkins_tag}'
+      - 'docker-gpii-preferences-dataloader-{jenkins_tag}-build'
+      - 'docker-gpii-preferences-dataloader-{jenkins_tag}-release'
+      - 'docker-gpii-preferences-dataloader-{jenkins_tag}-cleanup'
+
+- job-template:
+    defaults: gpii-preferences-dataloader
+    name: 'docker-gpii-preferences-dataloader-{jenkins_tag}'
+    description: 'Builds, tests and pushes the GPII Preferences Server Docker image'
+    project-type: multijob
+    concurrent: false
+    node: '{jenkins_node}'
+    wrappers:
+      - timeout:
+          timeout: '{build_timeout}'
+          abort: yes
+    publishers:
+      - email:
+            recipients: '{email_recipient}'
+    scm:
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: docker
+          url: '{git_docker_repo}'
+          branches:
+            - '{git_docker_branch}'
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: app
+          url: '{git_app_repo}'
+          branches:
+            - '{git_app_branch}'
+    triggers:
+      - github
+      - reverse:
+          jobs: 'docker-gpii-universal-{jenkins_tag}'
+          result: success
+    builders:
+      - multijob:
+          name: Cleanup
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-preferences-dataloader-{jenkins_tag}-cleanup
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Build
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-preferences-dataloader-{jenkins_tag}-build
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Release
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-preferences-dataloader-{jenkins_tag}-release
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+
+- job-template:
+    defaults: gpii-preferences-dataloader
+    name: 'docker-gpii-preferences-dataloader-{jenkins_tag}-cleanup'
+    description: 'Removes build artifacts'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+
+- job-template:
+    defaults: gpii-preferences-dataloader
+    name: 'docker-gpii-preferences-dataloader-{jenkins_tag}-build'
+    description: 'Builds Docker image'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker build --pull -t {docker_username}/{docker_image}:{docker_tag} .
+
+- job-template:
+    defaults: gpii-preferences-dataloader
+    name: 'docker-gpii-preferences-dataloader-{jenkins_tag}-release'
+    description: 'Publishes to Docker Hub'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - gpii-preferences-dataloader-docker-push
+    builders:
+      - critical-block-start
+      - shell: docker push {docker_username}/{docker_image}:{docker_tag}
+      - critical-block-end

--- a/jenkins_jobs/docker-gpii-qi-dashboard-backend.yml
+++ b/jenkins_jobs/docker-gpii-qi-dashboard-backend.yml
@@ -1,0 +1,177 @@
+---
+# These jobs will build the GPII/qi-dashboard-backend Docker image.
+#
+# It's necessary to specify both the repository where Dockerfile exists
+# as well as the actual GPII/qi-dashboard-backend repository. This way, Jenkins
+# will be notified when both change.
+#
+# The variables git_*_{repo,branch} allow for the flexibility to pick
+# and match the branches are necessary. Ideally, they should be equal
+# but we are not enforcing this here in case some odd situation shows
+# up and we need to break away from that convention.
+#
+# A similar situation happens with the docker_tag variable.
+#
+# It should be noted that the version of Node.js being used in each
+# project is really defined in the Dockerfile (FROM). The goal of
+# specifying it here as well is because we need this information at
+# configuration time to know which Jenkins job we should be downstream
+# to.
+#
+# Before each build, a cleanup runs to remove the previously created
+# layer so avoid working with stale data. This is necessary during
+# code changes otherwise Docker will be happy with the existing
+# layer that matches the string statement from the Dockerfile. This
+# is useful for lowers layers (e.g. CentOS and Node.js) so we don't
+# have to rebuild, but it creates a problem here. We still taking
+# advantage of not having to rebuild lower layers, but rebuilding
+# our layers is unavoidable.
+#
+# Finally, you should create a new project node for each version
+# that should be built.
+
+- defaults:
+    name: gpii-qi-dashboard-backend
+    git_app_repo: https://github.com/avtar/qi-dashboard-backend-demo.git
+    git_app_branch: master
+    git_docker_repo: https://github.com/avtar/qi-dashboard-backend-demo.git
+    git_docker_branch: master
+    nodejs_version: 4.4.1
+    docker_username: gpii
+    docker_image: qi-dashboard-backend
+    docker_tag: latest
+    build_timeout: 30
+    email_recipient: gpii-infra-notifications@lists.gpii.net
+    jenkins_node: i-0027.tor1.inclusivedesign.ca
+
+- project:
+    name: gpii-qi-dashboard-backend-master
+    jenkins_tag: master
+    git_app_branch: master
+    git_docker_branch: master
+    nodejs_version: 4.4.1
+    docker_tag: latest
+    jobs:
+      - 'docker-gpii-qi-dashboard-backend-all'
+
+
+# WARNING: Be careful changing anything below.
+
+# Used to ensure only one `docker push` command runs at a time
+- wrapper:
+    name: gpii-qi-dashboard-backend-docker-push
+    wrappers:
+      - exclusion:
+          resources:
+            - 'gpii-qi-dashboard-backend-docker-push'
+
+- job-group:
+    name: 'docker-gpii-qi-dashboard-backend-all'
+    jobs:
+      - 'docker-gpii-qi-dashboard-backend-{jenkins_tag}'
+      - 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-build'
+#      - 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-test'
+      - 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-release'
+      - 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-cleanup'
+
+- job-template:
+    defaults: gpii-qi-dashboard-backend
+    name: 'docker-gpii-qi-dashboard-backend-{jenkins_tag}'
+    description: 'Builds, tests and pushes the GPII QI Dashboard Backend Docker image'
+    project-type: multijob
+    concurrent: false
+    node: '{jenkins_node}'
+    wrappers:
+      - timeout:
+          timeout: '{build_timeout}'
+          abort: yes
+    publishers:
+      - email:
+            recipients: '{email_recipient}'
+    scm:
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: docker
+          url: '{git_docker_repo}'
+          branches:
+            - '{git_docker_branch}'
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: app
+          url: '{git_app_repo}'
+          branches:
+            - '{git_app_branch}'
+    triggers:
+      - github
+      - reverse:
+          jobs: 'docker-idi-nodejs-{nodejs_version}'
+          result: success
+    builders:
+      - multijob:
+          name: Cleanup
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-qi-dashboard-backend-{jenkins_tag}-cleanup
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Build
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-qi-dashboard-backend-{jenkins_tag}-build
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+#      - multijob:
+#          name: Test
+#          condition: SUCCESSFUL
+#          projects:
+#            - name: docker-gpii-qi-dashboard-backend-{jenkins_tag}-test
+#              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Release
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-qi-dashboard-backend-{jenkins_tag}-release
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+
+- job-template:
+    defaults: gpii-qi-dashboard-backend
+    name: 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-cleanup'
+    description: 'Removes build artifacts'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+
+- job-template:
+    defaults: gpii-qi-dashboard-backend
+    name: 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-build'
+    description: 'Builds Docker image'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker build --pull -t {docker_username}/{docker_image}:{docker_tag} .
+
+#- job-template:
+#    defaults: gpii-qi-dashboard-backend
+#    name: 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-test'
+#    description: 'Runs a test container'
+#    node: '{jenkins_node}'
+#    workspace: $parent_workspace
+#    builders:
+#      - shell: docker run --rm -i {docker_username}/{docker_image}:{docker_tag} node --eval "console.log('OK');"
+
+# Tag operation is forced in case they've happened in the past from a previous build (no-op)
+# Push is forced otherwise a prompt is displayed asking if really want to publish to public registry
+- job-template:
+    defaults: gpii-qi-dashboard-backend
+    name: 'docker-gpii-qi-dashboard-backend-{jenkins_tag}-release'
+    description: 'Publishes to Docker Hub'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - gpii-qi-dashboard-backend-docker-push
+    builders:
+      - critical-block-start
+      - shell: docker push {docker_username}/{docker_image}:{docker_tag}
+      - critical-block-end

--- a/jenkins_jobs/docker-gpii-qi-dashboard-frontend.yml
+++ b/jenkins_jobs/docker-gpii-qi-dashboard-frontend.yml
@@ -1,0 +1,161 @@
+---
+# These jobs will build the GPII/qi-dashboard-frontend Docker image.
+#
+# It's necessary to specify both the repository where Dockerfile exists
+# as well as the actual GPII/qi-dashboard-frontend repository. This way, Jenkins
+# will be notified when both change.
+#
+# The variables git_*_{repo,branch} allow for the flexibility to pick
+# and match the branches are necessary. Ideally, they should be equal
+# but we are not enforcing this here in case some odd situation shows
+# up and we need to break away from that convention.
+#
+# A similar situation happens with the docker_tag variable.
+#
+# It should be noted that the version of Node.js being used in each
+# project is really defined in the Dockerfile (FROM). The goal of
+# specifying it here as well is because we need this information at
+# configuration time to know which Jenkins job we should be downstream
+# to.
+#
+# Before each build, a cleanup runs to remove the previously created
+# layer so avoid working with stale data. This is necessary during
+# code changes otherwise Docker will be happy with the existing
+# layer that matches the string statement from the Dockerfile. This
+# is useful for lowers layers (e.g. CentOS and Node.js) so we don't
+# have to rebuild, but it creates a problem here. We still taking
+# advantage of not having to rebuild lower layers, but rebuilding
+# our layers is unavoidable.
+#
+# Finally, you should create a new project node for each version
+# that should be built.
+
+- defaults:
+    name: gpii-qi-dashboard-frontend
+    git_app_repo: https://github.com/cindyli/qi-dashboard-frontend-demo.git
+    git_app_branch: GPII-2204
+    git_docker_repo: https://github.com/cindyli/qi-dashboard-frontend-demo.git
+    git_docker_branch: GPII-2204
+    nodejs_version: lts
+    docker_username: gpii
+    docker_image: qi-dashboard-frontend
+    docker_tag: latest
+    build_timeout: 30
+    email_recipient: gpii-infra-notifications@lists.gpii.net
+    jenkins_node: i-0027.tor1.inclusivedesign.ca
+
+- project:
+    name: gpii-qi-dashboard-frontend-master
+    jenkins_tag: GPII-2204
+    git_app_branch: GPII-2204
+    git_docker_branch: GPII-2204
+    nodejs_version: lts
+    docker_tag: latest
+    jobs:
+      - 'docker-gpii-qi-dashboard-frontend-all'
+
+
+# WARNING: Be careful changing anything below.
+
+# Used to ensure only one `docker push` command runs at a time
+- wrapper:
+    name: gpii-qi-dashboard-frontend-docker-push
+    wrappers:
+      - exclusion:
+          resources:
+            - 'gpii-qi-dashboard-frontend-docker-push'
+
+- job-group:
+    name: 'docker-gpii-qi-dashboard-frontend-all'
+    jobs:
+      - 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}'
+      - 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}-build'
+      - 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}-release'
+      - 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}-cleanup'
+
+- job-template:
+    defaults: gpii-qi-dashboard-frontend
+    name: 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}'
+    description: 'Builds, tests and pushes the GPII QI Dashboard Frontend Docker image'
+    project-type: multijob
+    concurrent: false
+    node: '{jenkins_node}'
+    wrappers:
+      - timeout:
+          timeout: '{build_timeout}'
+          abort: yes
+    publishers:
+      - email:
+            recipients: '{email_recipient}'
+    scm:
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: docker
+          url: '{git_docker_repo}'
+          branches:
+            - '{git_docker_branch}'
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: app
+          url: '{git_app_repo}'
+          branches:
+            - '{git_app_branch}'
+    triggers:
+      - github
+      - reverse:
+          jobs: 'docker-idi-nodejs-{nodejs_version}'
+          result: success
+    builders:
+      - multijob:
+          name: Cleanup
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-qi-dashboard-frontend-{jenkins_tag}-cleanup
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Build
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-qi-dashboard-frontend-{jenkins_tag}-build
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Release
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-qi-dashboard-frontend-{jenkins_tag}-release
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+
+- job-template:
+    defaults: gpii-qi-dashboard-frontend
+    name: 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}-cleanup'
+    description: 'Removes build artifacts'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+
+- job-template:
+    defaults: gpii-qi-dashboard-frontend
+    name: 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}-build'
+    description: 'Builds Docker image'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker build --pull -t {docker_username}/{docker_image}:{docker_tag} .
+
+# Tag operation is forced in case they've happened in the past from a previous build (no-op)
+# Push is forced otherwise a prompt is displayed asking if really want to publish to public registry
+- job-template:
+    defaults: gpii-qi-dashboard-frontend
+    name: 'docker-gpii-qi-dashboard-frontend-{jenkins_tag}-release'
+    description: 'Publishes to Docker Hub'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - gpii-qi-dashboard-frontend-docker-push
+    builders:
+      - critical-block-start
+      - shell: docker push {docker_username}/{docker_image}:{docker_tag}
+      - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -1,0 +1,176 @@
+---
+# These jobs will build the GPII/universal Docker image.
+#
+# It's necessary to specify both the repository where Dockerfile exists
+# as well as the actual GPII/universal repository. This way, Jenkins
+# will be notified when both change.
+#
+# The variables git_*_{repo,branch} allow for the flexibility to pick
+# and match the branches are necessary. Ideally, they should be equal
+# but we are not enforcing this here in case some odd situation shows
+# up and we need to break away from that convention.
+#
+# A similar situation happens with the docker_tag variable.
+#
+# It should be noted that the version of Node.js being used in each
+# project is really defined in the Dockerfile (FROM). The goal of
+# specifying it here as well is because we need this information at
+# configuration time to know which Jenkins job we should be downstream
+# to.
+#
+# Before each build, a cleanup runs to remove the previously created
+# layer so avoid working with stale data. This is necessary during
+# code changes otherwise Docker will be happy with the existing
+# layer that matches the string statement from the Dockerfile. This
+# is useful for lowers layers (e.g. CentOS and Node.js) so we don't
+# have to rebuild, but it creates a problem here. We still taking
+# advantage of not having to rebuild lower layers, but rebuilding
+# our layers is unavoidable.
+#
+# Finally, you should create a new project node for each version
+# that should be built.
+
+- defaults:
+    name: gpii-universal
+    git_app_repo: https://github.com/GPII/universal.git
+    git_app_branch: master
+    git_docker_repo: https://github.com/GPII/universal.git
+    git_docker_branch: master
+    nodejs_version: lts
+    docker_username: gpii
+    docker_image: universal
+    docker_tag: latest
+    build_timeout: 30
+    email_recipient: gpii-infra-notifications@lists.gpii.net
+    jenkins_node: i-0027.tor1.inclusivedesign.ca
+
+- project:
+    name: gpii-universal-master
+    jenkins_tag: master
+    git_app_branch: master
+    git_docker_branch: master
+    nodejs_version: lts
+    docker_tag: latest
+    jobs:
+      - 'docker-gpii-universal-all'
+
+# WARNING: Be careful changing anything below.
+
+# Used to ensure only one `docker push` command runs at a time
+- wrapper:
+    name: gpii-universal-docker-push
+    wrappers:
+      - exclusion:
+          resources:
+            - 'gpii-universal-docker-push'
+
+- job-group:
+    name: 'docker-gpii-universal-all'
+    jobs:
+      - 'docker-gpii-universal-{jenkins_tag}'
+      - 'docker-gpii-universal-{jenkins_tag}-build'
+#      - 'docker-gpii-universal-{jenkins_tag}-test'
+      - 'docker-gpii-universal-{jenkins_tag}-release'
+      - 'docker-gpii-universal-{jenkins_tag}-cleanup'
+
+- job-template:
+    defaults: gpii-universal
+    name: 'docker-gpii-universal-{jenkins_tag}'
+    description: 'Builds, tests and pushes the GPII Universal Docker image'
+    project-type: multijob
+    concurrent: false
+    node: '{jenkins_node}'
+    wrappers:
+      - timeout:
+          timeout: '{build_timeout}'
+          abort: yes
+    publishers:
+      - email:
+            recipients: '{email_recipient}'
+    scm:
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: docker
+          url: '{git_docker_repo}'
+          branches:
+            - '{git_docker_branch}'
+      - git:
+          skip-tag: true
+          shallow-clone: true
+          basedir: app
+          url: '{git_app_repo}'
+          branches:
+            - '{git_app_branch}'
+    triggers:
+      - github
+      - reverse:
+          jobs: 'docker-idi-nodejs-{nodejs_version}'
+          result: success
+    builders:
+      - multijob:
+          name: Cleanup
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-universal-{jenkins_tag}-cleanup
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Build
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-universal-{jenkins_tag}-build
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+#      - multijob:
+#          name: Test
+#          condition: SUCCESSFUL
+#          projects:
+#            - name: docker-gpii-universal-{jenkins_tag}-test
+#              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
+          name: Release
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-universal-{jenkins_tag}-release
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+
+- job-template:
+    defaults: gpii-universal
+    name: 'docker-gpii-universal-{jenkins_tag}-cleanup'
+    description: 'Removes build artifacts'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+
+- job-template:
+    defaults: gpii-universal
+    name: 'docker-gpii-universal-{jenkins_tag}-build'
+    description: 'Builds Docker image'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: docker build --pull -t {docker_username}/{docker_image}:{docker_tag} .
+
+#- job-template:
+#    defaults: gpii-universal
+#    name: 'docker-gpii-universal-{jenkins_tag}-test'
+#    description: 'Runs a test container'
+#    node: '{jenkins_node}'
+#    workspace: $parent_workspace
+#    builders:
+#      - shell: docker run --rm -i {docker_username}/{docker_image}:{docker_tag} node --eval "console.log('OK');"
+
+# Tag operation is forced in case they've happened in the past from a previous build (no-op)
+# Push is forced otherwise a prompt is displayed asking if really want to publish to public registry
+- job-template:
+    defaults: gpii-universal
+    name: 'docker-gpii-universal-{jenkins_tag}-release'
+    description: 'Publishes to Docker Hub'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    wrappers:
+      - gpii-universal-docker-push
+    builders:
+      - critical-block-start
+      - shell: docker push {docker_username}/{docker_image}:{docker_tag}
+      - critical-block-end


### PR DESCRIPTION
This is a long standing task that we never got around to do. Now that the GPII containers don't depend on the IDI/CentOS and IDI/Node.js images, this can be migrated safely.

@amatas @mrtyler @avtar, could you review this?

I've uploaded the jobs to ci.gpii.net temporarily to test and they seem to work, except for the following old errors (that also happen on ci.inclusivedesign.ca):
* First Discovery Server build is broken (as expected)
* QI Dashboard Frontend build is broken (depending on Ansible)

Additionally, I just invited 'gpii-bot' to the GitHub team that has access to the 'ops-shared' repository. @mrtyler @amatas could you find the email and accept the invitation?

Thanks in advance.