### PR TITLE
Update Vagrant box before starting

### DIFF
--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -57,7 +57,7 @@
       #
       # Since the node_modules directory might not be synchronized between VM and host (GPII-2060)
       # it's necessary to run `npm install` on the host to get auxiliary tools installed (e.g grunt)
-      - shell: BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox && npm install
+      - shell: vagrant box update && BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox && npm install
 
 - job:
     name: linux-code-analysis

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -51,7 +51,7 @@
       #
       # Since the node_modules directory might not be synchronized between VM and host (GPII-2060)
       # it's necessary to run `npm install` on the host to get auxiliary tools installed (e.g grunt)
-      - shell: BUILD_ID=gpii-nexus vagrant up --provider virtualbox && npm install
+      - shell: vagrant box update && BUILD_ID=gpii-nexus vagrant up --provider virtualbox && npm install
 
 - job:
     name: nexus-code-analysis

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -63,7 +63,7 @@
       #
       # Since the node_modules directory might not be synchronized between VM and host (GPII-2060)
       # it's necessary to run `npm install` on the host to get auxiliary tools installed (e.g grunt)
-      - shell: BUILD_ID=gpii-universal DISPLAY=:0 vagrant up --provider virtualbox && npm install
+      - shell: vagrant box update && BUILD_ID=gpii-universal DISPLAY=:0 vagrant up --provider virtualbox && npm install
 
 - job:
     name: universal-code-analysis


### PR DESCRIPTION
I have not included the Windows jobs because I'm not sure how "&&" would translate in Powershell (and I can't test that easily with Jenkins/Vagrant here). I can update this PR if anyone has any idea about how that should be done.

This should help with the recent issue where a new box update was missing and admins have to run `vagrant box update` manually on the Jenkins build node.