### PR TITLE
Remove `npm install` step

### DIFF
--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -54,10 +54,7 @@
     builders:
       # Setting BUILD_ID for the vagrant process to make sure the Jenkins process tree killer
       # doesn't kill the VM before the next job is started.
-      #
-      # Since the node_modules directory might not be synchronized between VM and host (GPII-2060)
-      # it's necessary to run `npm install` on the host to get auxiliary tools installed (e.g grunt)
-      - shell: BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox && npm install
+      - shell: BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox
 
 - job:
     name: linux-code-analysis
@@ -65,7 +62,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: $(npm bin)/grunt lint
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync/linux; $(npm bin)/grunt lint'
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -76,7 +73,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: grunt unit-tests
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync/linux; $(npm bin)/grunt unit-tests'
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -87,7 +84,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: grunt acceptance-tests
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync/linux; $(npm bin)/grunt acceptance-tests'
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -99,4 +96,3 @@
     workspace: $parent_workspace
     builders:
       - shell: vagrant destroy -f
-        

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -51,7 +51,7 @@
       #
       # Since the node_modules directory might not be synchronized between VM and host (GPII-2060)
       # it's necessary to run `npm install` on the host to get auxiliary tools installed (e.g grunt)
-      - shell: BUILD_ID=gpii-nexus vagrant up --provider virtualbox && npm install
+      - shell: BUILD_ID=gpii-nexus vagrant up --provider virtualbox
 
 - job:
     name: nexus-code-analysis
@@ -59,7 +59,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: $(npm bin)/grunt lint
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync/nexus; $(npm bin)/grunt lint'
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -70,7 +70,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: grunt tests
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync/nexus; $(npm bin)/grunt tests'
     publishers:
       - email:
           recipients: ci@lists.gpii.net

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -60,10 +60,7 @@
     builders:
       # Setting BUILD_ID for the vagrant process to make sure the Jenkins process tree killer
       # doesn't kill the VM before the next job is started.
-      #
-      # Since the node_modules directory might not be synchronized between VM and host (GPII-2060)
-      # it's necessary to run `npm install` on the host to get auxiliary tools installed (e.g grunt)
-      - shell: BUILD_ID=gpii-universal DISPLAY=:0 vagrant up --provider virtualbox && npm install
+      - shell: BUILD_ID=gpii-universal DISPLAY=:0 vagrant up --provider virtualbox
 
 - job:
     name: universal-code-analysis
@@ -71,7 +68,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: $(npm bin)/grunt lint
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync/universal; $(npm bin)/grunt lint'
     publishers:
       - email:
           recipients: ci@lists.gpii.net


### PR DESCRIPTION
`npm install` is already running once inside the VM (see [vagrant-vars.yml](https://github.com/GPII/universal/blob/master/provisioning/vagrant-vars.yml#L7)).

Running `npm install` outside the VM just to run grunt doesn't seem necessary in CI.

I'm suggesting that step be removed and the VM's grunt be used instead. This way it's not necessary to have nodejs/npm/grunt on the CI node either.