### PR TITLE
Move GPII related repositories to gpii-ops org

### DIFF
--- a/jenkins_jobs/ansible-roles-gpii.yml
+++ b/jenkins_jobs/ansible-roles-gpii.yml
@@ -1,0 +1,55 @@
+- project:
+    name: ansible-roles
+    jobs:
+        - '{role}':
+            role: ansible-gpii-ci-worker
+        - '{role}':
+            role: ansible-gpii-version-updater
+
+- job-template:
+    name: '{role}'
+    project-type: 'freestyle'
+    scm:
+        - git:
+          url: 'https://github.com/gpii-ops/{role}.git'
+            skip-tag: true
+            branches:
+                - master
+    triggers:
+        - github
+        - pollscm:
+            cron: "H/5 * * * *"
+        - timed: '@daily'
+
+    node: h-0005.tor1.inclusivedesign.ca
+    builders:
+        # Several things going on here:
+        #
+        # - The pip provided by CentOS 7 via python-virtualenv has trouble
+        # installing things (see
+        # https://github.com/pypa/setuptools/issues/937). We need an upgraded
+        # pip *before* we can install the other requirements, so we do that as
+        # its own step. We nudge it up from the CentOS 7 default to be
+        # minimally opinionated about which version gets installed.
+        #
+        # - /tmp on Jenkins node h-0005.tor1.inclusivedesign.ca is mounted
+        # noexec, which prevents pycyrpto (in requirements.txt) from running
+        # autoconf (see https://bugs.launchpad.net/pycrypto/+bug/1294670). So
+        # we make a local tmpdir and use it when installing from
+        # requirements.txt.
+        #
+        # - This is a dubious amount of work to do in a build one-liner. I
+        # considered moving to Tox but decided to stop here. If you are
+        # thinking of adding more steps here, please consider instead moving to
+        # Tox (or a Makefile or a shell script or something).
+        - shell: >
+            virtualenv venv &&
+            . venv/bin/activate &&
+            pip install "pip > 1.4.1" &&
+            mkdir -p pip-tmp &&
+            TMPDIR=pip-tmp pip install -r requirements.txt &&
+            molecule --debug test
+
+    publishers:
+      - email:
+            recipients: gpii-infra-notifications@lists.gpii.net

--- a/jenkins_jobs/ansible-roles-idi.yml
+++ b/jenkins_jobs/ansible-roles-idi.yml
@@ -8,10 +8,6 @@
         - '{role}':
             role: ansible-grafana
         - '{role}':
-            role: ansible-gpii-ci-worker
-        - '{role}':
-            role: ansible-gpii-version-updater
-        - '{role}':
             role: ansible-influxdb
         - '{role}':
             role: ansible-nginx-common


### PR DESCRIPTION
This PR is mean to be to split the list of ops repositories from idi org and start using gpii-ops org for GPII related repositories.

The CI doesn't check all the repositories (yet), so I'm moving the current repos listed in the Jenkins definition

Also, this PR will solve some issues that we have with the updates of the repos at the CI.

i.e. https://ci.gpii.net/blue/organizations/jenkins/ansible-gpii-ci-worker/detail/ansible-gpii-ci-worker/198/pipeline