### PR TITLE
GPII-2515 - Adjust build commands

### DIFF
--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -54,7 +54,7 @@
     builders:
       # Setting BUILD_ID for the vagrant process to make sure the Jenkins process tree killer
       # doesn't kill the VM before the next job is started.
-      - shell: BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox && npm install
+      - shell: BUILD_ID=gpii-linux DISPLAY=:0 vagrant up --provider virtualbox
 
 - job:
     name: linux-code-analysis
@@ -62,7 +62,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: grunt lint
+      - shell: vagrant ssh -c 'cd /home/vagrant/sync; $(npm bin)/grunt lint'
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -73,7 +73,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: grunt unit-tests
+      - shell: npm run test:vagrantUnit
     publishers:
       - email:
           recipients: ci@lists.gpii.net
@@ -84,7 +84,7 @@
     node: h-0005.tor1.inclusivedesign.ca
     workspace: $parent_workspace
     builders:
-      - shell: grunt acceptance-tests
+      - shell: npm run test:vagrantAcceptance
     publishers:
       - email:
           recipients: ci@lists.gpii.net


### PR DESCRIPTION
Adjust build commands after https://github.com/GPII/linux/pull/94

Test results:

```
$ DISPLAY=:0 vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'inclusivedesign/fedora27'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'inclusivedesign/fedora27' is up to date...
==> default: Setting the name of the VM: linux_default_1527074252100_88186
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 8081 (guest) => 8081 (host) (adapter 1)
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Setting hostname...
==> default: Mounting shared folders...
    default: /home/vagrant/sync => /home/gtirloni/linux
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: Running provisioner: shell...
    default: Running: inline script
    default: - extracting facts to /root/.ansible/roles/facts
    default: - facts was installed successfully
    default: - extracting nodejs to /root/.ansible/roles/nodejs
    default: - nodejs was installed successfully
    default: - extracting gpii-framework to /root/.ansible/roles/gpii-framework
    default: - gpii-framework was installed successfully
    default: 
    default: PLAY [localhost] ***************************************************************
    default: 
    default: TASK [Gathering Facts] *********************************************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Set Fedora related facts] ****************************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Set CentOS related facts] ****************************************
    default: skipping: [localhost]
    default: 
    default: TASK [facts : Determine if Atomic] *********************************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Set Atomic related facts] ****************************************
    default: skipping: [localhost]
    default: 
    default: TASK [facts : Determine if has RPM] ********************************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Set RPM related facts] *******************************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Check for Docker related file] ***********************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Set Docker fact to true] *****************************************
    default: skipping: [localhost]
    default: 
    default: TASK [facts : Check for Vagrant related directory] *****************************
    default: ok: [localhost]
    default: 
    default: TASK [facts : Set Vagrant fact to true] ****************************************
    default: ok: [localhost]
    default: 
    default: TASK [nodejs : Include OS-specific variables] **********************************
    default: ok: [localhost]
    default: 
    default: TASK [nodejs : Install Yum Utilities] ******************************************
    default: ok: [localhost]
    default: 
    default: TASK [nodejs : Enable Node.js LTS repository on Fedora] ************************
    default: changed: [localhost]
    default: 
    default: TASK [nodejs : Enable Node.js Current repository on Fedora] ********************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Install latest Node.js version on Fedora] ***********************
    default: changed: [localhost]
    default: 
    default: TASK [nodejs : Install specific Node.js version on Fedora] *********************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Install additional RPM packages on Fedora] **********************
    default: changed: [localhost] => (item=[u'git', u'gcc-c++', u'orca', u'glib2-devel', u'PackageKit-glib-devel', u'json-glib-devel', u'libXrandr-devel', u'libXrender-devel', u'libX11-devel', u'xorg-x11-proto-devel', u'alsa-lib-devel', u'tuxguitar', u'v8', u'v8-devel', u'libstdc++', u'gcc-c++', u'gyp', u'http-parser', u'http-parser-devel', u'libstdc++-devel', u'libuv', u'libuv-devel'])
    default: 
    default: TASK [nodejs : Ensure rsync is installed for npm path workaround if a Fedora Vagrant environment is being used] ***
    default: ok: [localhost]
    default: 
    default: TASK [nodejs : Enable Node.js LTS repository on CentOS] ************************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Enable Node.js Current repository on CentOS] ********************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Install latest Node.js version on CentOS] ***********************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Install specific Node.js version on CentOS] *********************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Fail if nodejs- RPM packages are specified in nodejs_app_rpm_packages] ***
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Install additional RPM packages on CentOS] **********************
    default: skipping: [localhost] => (item=[]) 
    default: 
    default: TASK [nodejs : Enable Yarn repository on CentOS/Fedora] ************************
    default: changed: [localhost]
    default: 
    default: TASK [nodejs : Install Yarn package manager on CentOS/Fedora] ******************
    default: changed: [localhost]
    default: 
    default: TASK [nodejs : Ensure rsync is installed for npm path workaround if a CentOS Vagrant environment is being used] ***
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Adjust npm version] *********************************************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Install required npm packages] **********************************
    default: changed: [localhost] => (item=grunt-cli)
    default: changed: [localhost] => (item=node-gyp)
    default: 
    default: TASK [nodejs : Install nodemon if a development environment is being used] *****
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Ensure the application group exists] ****************************
    default: changed: [localhost]
    default: 
    default: TASK [nodejs : Ensure the application user account exists] *********************
    default: changed: [localhost]
    default: 
    default: TASK [nodejs : Clone application repository] ***********************************
    default: skipping: [localhost]
    default: 
    default: TASK [nodejs : Make sure the application install directory exists and is owned by the appropriate user] ***
    default: ok: [localhost]
    default: 
    default: TASK [nodejs : Run application related commands as the application user] *******
    default: changed: [localhost] => (item=npm install)
    default: changed: [localhost] => (item=grunt --force build)
    default: 
    default: TASK [gpii-framework : include_tasks] ******************************************
    default: included: /root/.ansible/roles/gpii-framework/tasks/install.yml for localhost
    default: 
    default: TASK [gpii-framework : Install application related RPM packages on Fedora] *****
    default: ok: [localhost] => (item=[u'orca'])
    default: 
    default: TASK [gpii-framework : include_tasks] ******************************************
    default: included: /root/.ansible/roles/gpii-framework/tasks/configure.yml for localhost
    default: 
    default: TASK [gpii-framework : Check to see if the Orca user directory exists] *********
    default: ok: [localhost]
    default: 
    default: TASK [gpii-framework : Create Orca user directory if required] *****************
    default: changed: [localhost]
    default: 
    default: TASK [gpii-framework : Create Orca configuration file] *************************
    default: changed: [localhost]
    default: 
    default: TASK [gpii-framework : Enable and start PackageKit] ****************************
    default: changed: [localhost]
    default: 
    default: PLAY RECAP *********************************************************************
    default: localhost                  : ok=28   changed=12   unreachable=0    failed=0   
==> default: Running provisioner: shell...
    default: Running: inline script



$ vagrant ssh -c 'cd /home/vagrant/sync; $(npm bin)/grunt lint'
Running "eslint:src" (eslint) task
>> 27 files lint free.

Running "jsonlint:src" (jsonlint) task
>> 10 files lint free.

Done.
Connection to 127.0.0.1 closed.




$ npm run test:vagrantUnit
...
11:23:44.429:  jq: ***************
11:23:44.429:  jq: All tests concluded: 114/114 total passed in 49574ms - PASS
11:23:44.430:  jq: ***************



$ npm run test:vagrantAcceptance
...
11:24:34.763:  jq: ***************
11:24:34.763:  jq: All tests concluded: 122/122 total passed in 21441ms - PASS
11:24:34.763:  jq: ***************
```