### PR TITLE
GPII-3191 Add installer artifact

### DIFF
--- a/jenkins_jobs/gpii-app.yml
+++ b/jenkins_jobs/gpii-app.yml
@@ -41,7 +41,7 @@
               predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
-          artifacts: "reports/**, coverage/**"
+          artifacts: "reports/**, coverage/**, installer/**"
           allow-empty: true
           only-if-success: true
 


### PR DESCRIPTION
With this change and https://github.com/GPII/gpii-app/pull/49 we should able to get the installer through the CI interface.