### PR TITLE
NOJIRA - Move cleanup into postbuildscript instead of multijob phase

### DIFF
--- a/jenkins_jobs/gpii-app.yml
+++ b/jenkins_jobs/gpii-app.yml
@@ -33,17 +33,22 @@
           projects:
             - name: gpii-app-test
               predefined-parameters: parent_workspace=$WORKSPACE
-      - multijob:
-          name: delete-gpii-app-vm
-          condition: SUCCESSFUL
-          projects:
-            - name: delete-gpii-app-vm
-              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
           artifacts: "reports/**, coverage/**, installer/**"
           allow-empty: true
           only-if-success: true
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - NOT_BUILT
+                - ABORTED
+                - FAILURE
+                - SUCCESS
+                - UNSTABLE
+              build-steps:
+                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: create-gpii-app-vm
@@ -61,7 +66,6 @@
           # Mark the build as failed
           fail: true
 
-
 - job:
     name: gpii-app-test
     description: 'GPII-APP tests'
@@ -78,12 +82,3 @@
           timeout: 60
           # Mark the build as failed
           fail: true
-
-
-- job:
-    name: delete-gpii-app-vm
-    description: 'Job responsible for deleting the test VM'
-    node: h-0005.tor1.incd.ca
-    workspace: $parent_workspace
-    builders:
-      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -39,17 +39,22 @@
           projects:
             - name: linux-acceptance-tests
               predefined-parameters: parent_workspace=$WORKSPACE
-      - multijob:
-          name: linux-delete-vm
-          condition: SUCCESSFUL
-          projects:
-            - name: linux-delete-vm
-              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
           artifacts: "reports/**, coverage/**"
           allow-empty: true
           only-if-success: true
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - NOT_BUILT
+                - ABORTED
+                - FAILURE
+                - SUCCESS
+                - UNSTABLE
+              build-steps:
+                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: linux-create-vm
@@ -93,11 +98,3 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
-
-- job:
-    name: linux-delete-vm
-    description: 'Job responsible for deleting the test VM'
-    node: h-0005.tor1.incd.ca
-    workspace: $parent_workspace
-    builders:
-      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -33,12 +33,18 @@
           projects:
             - name: nexus-unit-tests
               predefined-parameters: parent_workspace=$WORKSPACE
-      - multijob:
-          name: nexus-delete-vm
-          condition: SUCCESSFUL
-          projects:
-            - name: nexus-delete-vm
-              predefined-parameters: parent_workspace=$WORKSPACE
+    publishers:
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - NOT_BUILT
+                - ABORTED
+                - FAILURE
+                - SUCCESS
+                - UNSTABLE
+              build-steps:
+                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: nexus-create-vm
@@ -74,11 +80,3 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
-
-- job:
-    name: nexus-delete-vm
-    description: 'Job responsible for deleting the test VM'
-    node: h-0005.tor1.incd.ca
-    workspace: $parent_workspace
-    builders:
-      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -45,13 +45,18 @@
           projects:
             - name: universal-node-production-tests
               predefined-parameters: parent_workspace=$WORKSPACE
-      - multijob:
-          name: universal-delete-vm
-          condition: SUCCESSFUL
-          projects:
-            - name: universal-delete-vm
-              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - NOT_BUILT
+                - ABORTED
+                - FAILURE
+                - SUCCESS
+                - UNSTABLE
+              build-steps:
+                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
       - archive:
           artifacts: "reports/**, coverage/**"
           allow-empty: true
@@ -112,11 +117,3 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
-
-- job:
-    name: universal-delete-vm
-    description: 'Job responsible for deleting the test VM'
-    node: h-0005.tor1.incd.ca
-    workspace: $parent_workspace
-    builders:
-      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -39,17 +39,22 @@
           projects:
             - name: windows-acceptance-tests
               predefined-parameters: parent_workspace=$WORKSPACE
-      - multijob:
-          name: windows-delete-vm
-          condition: SUCCESSFUL
-          projects:
-            - name: windows-delete-vm
-              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
           artifacts: "reports/**, coverage/**"
           allow-empty: true
           only-if-success: true
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - NOT_BUILT
+                - ABORTED
+                - FAILURE
+                - SUCCESS
+                - UNSTABLE
+              build-steps:
+                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: windows-create-vm
@@ -93,11 +98,3 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
-
-- job:
-    name: windows-delete-vm
-    description: 'Job responsible for deleting the test VM'
-    node: h-0005.tor1.incd.ca
-    workspace: $parent_workspace
-    builders:
-      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f


### PR DESCRIPTION
Vagrant VMs usually aren't killed if there are failures in intermediate multijob phases because execution never reaches the last phase, given the completed/successful conditions to continue after each phase.

This PR moves the cleanup phase into a [postbuildscript](https://wiki.jenkins.io/display/JENKINS/PostBuildScript+Plugin) step that always runs. This is implemented in the [fluid-project/ci-service](https://github.com/fluid-project/ci-service) repository.