### PR TITLE
Revert "NOJIRA - Move cleanup into postbuildscript instead of multijob phase"

### DIFF
--- a/jenkins_jobs/gpii-app.yml
+++ b/jenkins_jobs/gpii-app.yml
@@ -33,22 +33,17 @@
           projects:
             - name: gpii-app-test
               predefined-parameters: parent_workspace=$WORKSPACE
+      - multijob:
+          name: delete-gpii-app-vm
+          condition: SUCCESSFUL
+          projects:
+            - name: delete-gpii-app-vm
+              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
           artifacts: "reports/**, coverage/**, installer/**"
           allow-empty: true
           only-if-success: true
-      - postbuildscript:
-          builders:
-            - role: SLAVE
-              build-on:
-                - NOT_BUILT
-                - ABORTED
-                - FAILURE
-                - SUCCESS
-                - UNSTABLE
-              build-steps:
-                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: create-gpii-app-vm
@@ -66,6 +61,7 @@
           # Mark the build as failed
           fail: true
 
+
 - job:
     name: gpii-app-test
     description: 'GPII-APP tests'
@@ -82,3 +78,12 @@
           timeout: 60
           # Mark the build as failed
           fail: true
+
+
+- job:
+    name: delete-gpii-app-vm
+    description: 'Job responsible for deleting the test VM'
+    node: h-0005.tor1.incd.ca
+    workspace: $parent_workspace
+    builders:
+      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/linux.yml
+++ b/jenkins_jobs/linux.yml
@@ -39,22 +39,17 @@
           projects:
             - name: linux-acceptance-tests
               predefined-parameters: parent_workspace=$WORKSPACE
+      - multijob:
+          name: linux-delete-vm
+          condition: SUCCESSFUL
+          projects:
+            - name: linux-delete-vm
+              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
           artifacts: "reports/**, coverage/**"
           allow-empty: true
           only-if-success: true
-      - postbuildscript:
-          builders:
-            - role: SLAVE
-              build-on:
-                - NOT_BUILT
-                - ABORTED
-                - FAILURE
-                - SUCCESS
-                - UNSTABLE
-              build-steps:
-                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: linux-create-vm
@@ -98,3 +93,11 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
+
+- job:
+    name: linux-delete-vm
+    description: 'Job responsible for deleting the test VM'
+    node: h-0005.tor1.incd.ca
+    workspace: $parent_workspace
+    builders:
+      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/nexus.yml
+++ b/jenkins_jobs/nexus.yml
@@ -33,18 +33,12 @@
           projects:
             - name: nexus-unit-tests
               predefined-parameters: parent_workspace=$WORKSPACE
-    publishers:
-      - postbuildscript:
-          builders:
-            - role: SLAVE
-              build-on:
-                - NOT_BUILT
-                - ABORTED
-                - FAILURE
-                - SUCCESS
-                - UNSTABLE
-              build-steps:
-                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
+      - multijob:
+          name: nexus-delete-vm
+          condition: SUCCESSFUL
+          projects:
+            - name: nexus-delete-vm
+              predefined-parameters: parent_workspace=$WORKSPACE
 
 - job:
     name: nexus-create-vm
@@ -80,3 +74,11 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
+
+- job:
+    name: nexus-delete-vm
+    description: 'Job responsible for deleting the test VM'
+    node: h-0005.tor1.incd.ca
+    workspace: $parent_workspace
+    builders:
+      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/universal.yml
+++ b/jenkins_jobs/universal.yml
@@ -45,18 +45,13 @@
           projects:
             - name: universal-node-production-tests
               predefined-parameters: parent_workspace=$WORKSPACE
+      - multijob:
+          name: universal-delete-vm
+          condition: SUCCESSFUL
+          projects:
+            - name: universal-delete-vm
+              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
-      - postbuildscript:
-          builders:
-            - role: SLAVE
-              build-on:
-                - NOT_BUILT
-                - ABORTED
-                - FAILURE
-                - SUCCESS
-                - UNSTABLE
-              build-steps:
-                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
       - archive:
           artifacts: "reports/**, coverage/**"
           allow-empty: true
@@ -117,3 +112,11 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
+
+- job:
+    name: universal-delete-vm
+    description: 'Job responsible for deleting the test VM'
+    node: h-0005.tor1.incd.ca
+    workspace: $parent_workspace
+    builders:
+      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f

--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -39,22 +39,17 @@
           projects:
             - name: windows-acceptance-tests
               predefined-parameters: parent_workspace=$WORKSPACE
+      - multijob:
+          name: windows-delete-vm
+          condition: SUCCESSFUL
+          projects:
+            - name: windows-delete-vm
+              predefined-parameters: parent_workspace=$WORKSPACE
     publishers:
       - archive:
           artifacts: "reports/**, coverage/**"
           allow-empty: true
           only-if-success: true
-      - postbuildscript:
-          builders:
-            - role: SLAVE
-              build-on:
-                - NOT_BUILT
-                - ABORTED
-                - FAILURE
-                - SUCCESS
-                - UNSTABLE
-              build-steps:
-                - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
 
 - job:
     name: windows-create-vm
@@ -98,3 +93,11 @@
     publishers:
       - email:
           recipients: ci@lists.gpii.net
+
+- job:
+    name: windows-delete-vm
+    description: 'Job responsible for deleting the test VM'
+    node: h-0005.tor1.incd.ca
+    workspace: $parent_workspace
+    builders:
+      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f


### PR DESCRIPTION
Reverts GPII/ci-service#50

```
Traceback (most recent call last):
  File "/usr/bin/jenkins-jobs", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/cmd.py", line 191, in main
    execute(options, config)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/cmd.py", line 372, in execute
    n_workers=options.n_workers)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/builder.py", line 350, in update_jobs
    self.parser.generateXML()
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/parser.py", line 342, in generateXML
    self.xml_jobs.append(self.getXMLForJob(job))
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/parser.py", line 352, in getXMLForJob
    self.gen_xml(xml, data)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/parser.py", line 359, in gen_xml
    module.gen_xml(self, xml, data)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/modules/publishers.py", line 6158, in gen_xml
    self.registry.dispatch('publisher', parser, publishers, action)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/registry.py", line 245, in dispatch
    func(parser, xml_parent, component_data)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/modules/publishers.py", line 3135, in postbuildscript
    builder)
  File "/usr/lib/python2.7/site-packages/jenkins_jobs/registry.py", line 249, in dispatch
    format(name, component_type))
jenkins_jobs.errors.JenkinsJobsException: Unknown entry point or macro 'role' for component type: 'builder'.
```