### PR TITLE
GPII-3919: Build, release, and clean up a numbered version in additio…

### DIFF
--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -171,7 +171,7 @@
     builders:
       - shell: |
           docker build --pull -t "{docker_username}/{docker_image}:{docker_tag}" .
-          CALCULATED_TAG="$(cat calculated_tag.env 2>/dev/null)"
+          CALCULATED_TAG="$(cat calculated_tag.env 2>/dev/null || echo '')"
           [ -n "$CALCULATED_TAG" ] && docker tag "{docker_username}/{docker_image}:{docker_tag}" "{docker_username}/{docker_image}:$CALCULATED_TAG"
 
 #- job-template:
@@ -197,7 +197,7 @@
       - critical-block-start
       - shell: |
           docker push "{docker_username}/{docker_image}:{docker_tag}"
-          CALCULATED_TAG="$(cat calculated_tag.env 2>/dev/null)"
+          CALCULATED_TAG="$(cat calculated_tag.env 2>/dev/null || echo '')"
           [ -n "$CALCULATED_TAG" ] && docker push "{docker_username}/{docker_image}:$CALCULATED_TAG"
           # This can't run in the cleanup step because cleanup runs at the start
           # of the next build (with a different calculated tag). So we cleanup

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -150,9 +150,11 @@
     builders:
       - shell: |
           date -u '+%Y%m%d%H%M%S' > timestamp.env
-          TIMESTAMP=$(cat timestamp.env)
-          docker build --pull -t {docker_username}/{docker_image}:$TIMESTAMP .
-          docker tag {docker_username}/{docker_image}:$TIMESTAMP {docker_username}/{docker_image}:{docker_tag}
+          git rev-parse --short HEAD > git_rev.env
+          TIMESTAMP=$(cat timestamp.env || echo "no_timestamp")
+          GIT_REV=$(cat git_rev.env || echo "no_git_rev")
+          docker build --pull -t {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV} .
+          docker tag {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV} {docker_username}/{docker_image}:{docker_tag}
 
 #- job-template:
 #    defaults: gpii-universal
@@ -176,11 +178,12 @@
     builders:
       - critical-block-start
       - shell: |
-          TIMESTAMP=$(cat timestamp.env)
-          docker push {docker_username}/{docker_image}:$TIMESTAMP
+          TIMESTAMP=$(cat timestamp.env || echo "no_timestamp")
+          GIT_REV=$(cat git_rev.env || echo "no_git_rev")
+          docker push {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}
           # This can't run in the cleanup step because cleanup runs at the start
           # of the next build (with a different tag). So we cleanup here after
           # pushing. The {docker_tag} image will stick around for debugging.
-          docker rmi -f {docker_username}/{docker_image}:$TIMESTAMP || echo "docker rmi failed. image probably does not exist"
+          docker rmi -f {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV} || echo "docker rmi failed. image probably does not exist"
           docker push {docker_username}/{docker_image}:{docker_tag}
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -66,6 +66,7 @@
     name: 'docker-gpii-universal-all'
     jobs:
       - 'docker-gpii-universal-{jenkins_tag}'
+      - 'docker-gpii-universal-{jenkins_tag}-calculate-tag'
       - 'docker-gpii-universal-{jenkins_tag}-build'
 #      - 'docker-gpii-universal-{jenkins_tag}-test'
       - 'docker-gpii-universal-{jenkins_tag}-release'
@@ -112,6 +113,12 @@
             - name: docker-gpii-universal-{jenkins_tag}-cleanup
               predefined-parameters: parent_workspace=$WORKSPACE/docker
       - multijob:
+          name: Calculate Tag
+          condition: SUCCESSFUL
+          projects:
+            - name: docker-gpii-universal-{jenkins_tag}-calculate-tag
+              predefined-parameters: parent_workspace=$WORKSPACE/docker
+      - multijob:
           name: Build
           condition: SUCCESSFUL
           projects:
@@ -138,8 +145,22 @@
     workspace: $parent_workspace
     builders:
       - shell: |
-          # See 'release' job for cleanup of $TIMESTAMP tag.
+          # See 'release' job for cleanup of image tagged with $CALCULATED_TAG.
           docker rmi -f "{docker_username}/{docker_image}:{docker_tag}" || echo "docker rmi failed. image probably does not exist"
+
+- job-template:
+    defaults: gpii-universal
+    name: 'docker-gpii-universal-{jenkins_tag}-calculate-tag'
+    description: 'Calculate a "static" tag to use in addition to "{docker_tag}". Write it to a file for use in later jobs.'
+    node: '{jenkins_node}'
+    workspace: $parent_workspace
+    builders:
+      - shell: |
+          TIMESTAMP="$(date -u '+%Y%m%d%H%M%S')"
+          GITREV="$(git rev-parse --short HEAD || echo 'no_gitrev')"
+          # FYI, JJB doesn't like dollar-curly format.
+          CALCULATED_TAG="$TIMESTAMP-$GITREV"
+          echo "$CALCULATED_TAG" > calculated_tag.env
 
 - job-template:
     defaults: gpii-universal
@@ -149,12 +170,9 @@
     workspace: $parent_workspace
     builders:
       - shell: |
-          date -u '+%Y%m%d%H%M%S' > timestamp.env
-          git rev-parse --short HEAD > git_rev.env
-          TIMESTAMP="$(cat timestamp.env 2>/dev/null || echo 'no_timestamp')"
-          GITREV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
-          docker build --pull -t "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV" .
-          docker tag "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV" "{docker_username}/{docker_image}:{docker_tag}"
+          docker build --pull -t "{docker_username}/{docker_image}:{docker_tag}" .
+          CALCULATED_TAG="$(cat calculated_tag.env 2>/dev/null)"
+          [ -n "$CALCULATED_TAG" ] && docker tag "{docker_username}/{docker_image}:{docker_tag}" "{docker_username}/{docker_image}:$CALCULATED_TAG"
 
 #- job-template:
 #    defaults: gpii-universal
@@ -178,12 +196,12 @@
     builders:
       - critical-block-start
       - shell: |
-          TIMESTAMP="$(cat timestamp.env 2>/dev/null || echo 'no_timestamp')"
-          GITREV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
-          docker push "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV"
-          # This can't run in the cleanup step because cleanup runs at the start
-          # of the next build (with a different tag). So we cleanup here after
-          # pushing. The {docker_tag} image will stick around for debugging.
-          docker rmi -f "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV" || echo "docker rmi failed. image probably does not exist"
           docker push "{docker_username}/{docker_image}:{docker_tag}"
+          CALCULATED_TAG="$(cat calculated_tag.env 2>/dev/null)"
+          [ -n "$CALCULATED_TAG" ] && docker push "{docker_username}/{docker_image}:$CALCULATED_TAG"
+          # This can't run in the cleanup step because cleanup runs at the start
+          # of the next build (with a different calculated tag). So we cleanup
+          # here after pushing. The {docker_tag} image is available for
+          # debugging until the next build runs and cleans up.
+          [ -n "$CALCULATED_TAG" ] && docker rmi -f "{docker_username}/{docker_image}:$CALCULATED_TAG" || echo "docker rmi failed. image probably does not exist"
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -204,4 +204,7 @@
           # here after pushing. The {docker_tag} image is available for
           # debugging until the next build runs and cleans up.
           [ -n "$CALCULATED_TAG" ] && (docker rmi -f "{docker_username}/{docker_image}:$CALCULATED_TAG" || echo "docker rmi failed. image probably does not exist")
+          # The above check returns non-zero when $CALCULATED_TAG is empty,
+          # which fails the build, which is not what we want.
+          true
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -139,7 +139,7 @@
     builders:
       - shell: |
           # See 'release' job for cleanup of $TIMESTAMP tag.
-          docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+          docker rmi -f "{docker_username}/{docker_image}:{docker_tag}" || echo "docker rmi failed. image probably does not exist"
 
 - job-template:
     defaults: gpii-universal
@@ -151,10 +151,10 @@
       - shell: |
           date -u '+%Y%m%d%H%M%S' > timestamp.env
           git rev-parse --short HEAD > git_rev.env
-          TIMESTAMP=$(cat timestamp.env || echo "no_timestamp")
-          GIT_REV=$(cat git_rev.env || echo "no_git_rev")
-          docker build --pull -t {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV} .
-          docker tag {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV} {docker_username}/{docker_image}:{docker_tag}
+          TIMESTAMP="$(cat timestamp.env 2>/dev/null || echo 'no_timestamp')"
+          GIT_REV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
+          docker build --pull -t "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}" .
+          docker tag "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}" "{docker_username}/{docker_image}:{docker_tag}"
 
 #- job-template:
 #    defaults: gpii-universal
@@ -178,12 +178,12 @@
     builders:
       - critical-block-start
       - shell: |
-          TIMESTAMP=$(cat timestamp.env || echo "no_timestamp")
-          GIT_REV=$(cat git_rev.env || echo "no_git_rev")
-          docker push {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}
+          TIMESTAMP="$(cat timestamp.env 2>/dev/null || echo 'no_timestamp')"
+          GIT_REV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
+          docker push "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}"
           # This can't run in the cleanup step because cleanup runs at the start
           # of the next build (with a different tag). So we cleanup here after
           # pushing. The {docker_tag} image will stick around for debugging.
-          docker rmi -f {docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV} || echo "docker rmi failed. image probably does not exist"
-          docker push {docker_username}/{docker_image}:{docker_tag}
+          docker rmi -f "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}" || echo "docker rmi failed. image probably does not exist"
+          docker push "{docker_username}/{docker_image}:{docker_tag}"
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -161,7 +161,7 @@
 #    node: '{jenkins_node}'
 #    workspace: $parent_workspace
 #    builders:
-#      - shell: docker run --rm -i {docker_username}/{docker_image}:$TIMESTAMP node --eval "console.log('OK');"
+#      - shell: docker run --rm -i {docker_username}/{docker_image}:{docker_tag} node --eval "console.log('OK');"
 
 # Tag operation is forced in case they've happened in the past from a previous build (no-op)
 # Push is forced otherwise a prompt is displayed asking if really want to publish to public registry

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -152,9 +152,9 @@
           date -u '+%Y%m%d%H%M%S' > timestamp.env
           git rev-parse --short HEAD > git_rev.env
           TIMESTAMP="$(cat timestamp.env 2>/dev/null || echo 'no_timestamp')"
-          GIT_REV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
-          docker build --pull -t "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}" .
-          docker tag "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}" "{docker_username}/{docker_image}:{docker_tag}"
+          GITREV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
+          docker build --pull -t "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV" .
+          docker tag "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV" "{docker_username}/{docker_image}:{docker_tag}"
 
 #- job-template:
 #    defaults: gpii-universal
@@ -179,11 +179,11 @@
       - critical-block-start
       - shell: |
           TIMESTAMP="$(cat timestamp.env 2>/dev/null || echo 'no_timestamp')"
-          GIT_REV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
-          docker push "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}"
+          GITREV="$(cat git_rev.env 2>/dev/null || echo 'no_git_rev')"
+          docker push "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV"
           # This can't run in the cleanup step because cleanup runs at the start
           # of the next build (with a different tag). So we cleanup here after
           # pushing. The {docker_tag} image will stick around for debugging.
-          docker rmi -f "{docker_username}/{docker_image}:${TIMESTAMP}_${GIT_REV}" || echo "docker rmi failed. image probably does not exist"
+          docker rmi -f "{docker_username}/{docker_image}:$TIMESTAMP_$GITREV" || echo "docker rmi failed. image probably does not exist"
           docker push "{docker_username}/{docker_image}:{docker_tag}"
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -137,7 +137,9 @@
     node: '{jenkins_node}'
     workspace: $parent_workspace
     builders:
-      - shell: docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
+      - shell: |
+          docker rmi -f {docker_username}/{docker_image}:$BUILD_ID || echo "docker rmi failed. image probably does not exist"
+          docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
 
 - job-template:
     defaults: gpii-universal
@@ -146,7 +148,9 @@
     node: '{jenkins_node}'
     workspace: $parent_workspace
     builders:
-      - shell: docker build --pull -t {docker_username}/{docker_image}:{docker_tag} .
+      - shell: |
+          docker build --pull -t {docker_username}/{docker_image}:$BUILD_ID .
+          docker tag {docker_username}/{docker_image}:$BUILD_ID {docker_username}/{docker_image}:{docker_tag}
 
 #- job-template:
 #    defaults: gpii-universal
@@ -155,7 +159,7 @@
 #    node: '{jenkins_node}'
 #    workspace: $parent_workspace
 #    builders:
-#      - shell: docker run --rm -i {docker_username}/{docker_image}:{docker_tag} node --eval "console.log('OK');"
+#      - shell: docker run --rm -i {docker_username}/{docker_image}:$BUILD_ID node --eval "console.log('OK');"
 
 # Tag operation is forced in case they've happened in the past from a previous build (no-op)
 # Push is forced otherwise a prompt is displayed asking if really want to publish to public registry
@@ -169,5 +173,7 @@
       - gpii-universal-docker-push
     builders:
       - critical-block-start
-      - shell: docker push {docker_username}/{docker_image}:{docker_tag}
+      - shell: |
+          docker push {docker_username}/{docker_image}:$BUILD_ID
+          docker push {docker_username}/{docker_image}:{docker_tag}
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -138,7 +138,7 @@
     workspace: $parent_workspace
     builders:
       - shell: |
-          docker rmi -f {docker_username}/{docker_image}:$BUILD_ID || echo "docker rmi failed. image probably does not exist"
+          # See 'release' job for cleanup of $TIMESTAMP tag.
           docker rmi -f {docker_username}/{docker_image}:{docker_tag} || echo "docker rmi failed. image probably does not exist"
 
 - job-template:
@@ -149,8 +149,10 @@
     workspace: $parent_workspace
     builders:
       - shell: |
-          docker build --pull -t {docker_username}/{docker_image}:$BUILD_ID .
-          docker tag {docker_username}/{docker_image}:$BUILD_ID {docker_username}/{docker_image}:{docker_tag}
+          date -u '+%Y%m%d%H%M%S' > timestamp.env
+          TIMESTAMP=$(cat timestamp.env)
+          docker build --pull -t {docker_username}/{docker_image}:$TIMESTAMP .
+          docker tag {docker_username}/{docker_image}:$TIMESTAMP {docker_username}/{docker_image}:{docker_tag}
 
 #- job-template:
 #    defaults: gpii-universal
@@ -159,7 +161,7 @@
 #    node: '{jenkins_node}'
 #    workspace: $parent_workspace
 #    builders:
-#      - shell: docker run --rm -i {docker_username}/{docker_image}:$BUILD_ID node --eval "console.log('OK');"
+#      - shell: docker run --rm -i {docker_username}/{docker_image}:$TIMESTAMP node --eval "console.log('OK');"
 
 # Tag operation is forced in case they've happened in the past from a previous build (no-op)
 # Push is forced otherwise a prompt is displayed asking if really want to publish to public registry
@@ -174,6 +176,11 @@
     builders:
       - critical-block-start
       - shell: |
-          docker push {docker_username}/{docker_image}:$BUILD_ID
+          TIMESTAMP=$(cat timestamp.env)
+          docker push {docker_username}/{docker_image}:$TIMESTAMP
+          # This can't run in the cleanup step because cleanup runs at the start
+          # of the next build (with a different tag). So we cleanup here after
+          # pushing. The {docker_tag} image will stick around for debugging.
+          docker rmi -f {docker_username}/{docker_image}:$TIMESTAMP || echo "docker rmi failed. image probably does not exist"
           docker push {docker_username}/{docker_image}:{docker_tag}
       - critical-block-end

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -203,5 +203,5 @@
           # of the next build (with a different calculated tag). So we cleanup
           # here after pushing. The {docker_tag} image is available for
           # debugging until the next build runs and cleans up.
-          [ -n "$CALCULATED_TAG" ] && docker rmi -f "{docker_username}/{docker_image}:$CALCULATED_TAG" || echo "docker rmi failed. image probably does not exist"
+          [ -n "$CALCULATED_TAG" ] && (docker rmi -f "{docker_username}/{docker_image}:$CALCULATED_TAG" || echo "docker rmi failed. image probably does not exist")
       - critical-block-end


### PR DESCRIPTION
…n to 'latest'.

EDIT: never mind, I remembered the trick of pointing `update-jenkins-jobs` to my branch so I can test in-place without merging to master. ~Testing Jenkins jobs is tricky, so I'm going to merge this and do it live! Please add feedback in spite of the Closed status and I will address it in a follow-up.~

EDIT: this didn't work because `$BUILD_ID` refers to the individual job, not the project, so it's not predictable. ~`$BUILD_ID` was the best thing I could find lying around in `env` (see https://ci.gpii.net/env-vars.html/). I noticed that `$BUILD_ID` handles deleted builds correctly, so it should be unique as long as we don't completely destroy the universal Jenkins jobs.~

EDIT: since BUILD_ID didn't work, I used an idea from https://stackoverflow.com/questions/22366808/passing-data-between-build-steps-in-jenkins to include a timestamp and the git revision in the tag. ~I wanted to use a timestamp (and/or the git hash associated with the build) but calculating one myself and passing it between jobs or messing with the Build Timestamp plugin is more Jenkins work than I am willing to put in to solve this problem.~

I added some defensive checks to handle a Job being run in isolation, even though this doesn't always work (e.g. Build job run on its own doesn't have the code checked out).

Here's a successful pipeline:
https://ci.gpii.net/job/docker-gpii-universal-master/173/

Here's a successful standalone release job (notice it only pushes `latest`):
https://ci.gpii.net/job/docker-gpii-universal-master-release/188/console