### PR TITLE
GPII-3842: Fixed vagrant ci test command in contrib projects.

### DIFF
--- a/jenkins_jobs/gpii-binder.yml
+++ b/jenkins_jobs/gpii-binder.yml
@@ -61,7 +61,7 @@
     node: h-0005.tor1.incd.ca
     workspace: $parent_workspace
     builders:
-      - shell: DISPLAY=:0 BUILD_ID=gpii-binder vagrant ci test --provider virtualbox
+      - shell: DISPLAY=:0 BUILD_ID=gpii-binder vagrant ci test
     publishers:
       - email:
           recipients: ci@lists.gpii.net

--- a/jenkins_jobs/gpii-express.yml
+++ b/jenkins_jobs/gpii-express.yml
@@ -61,7 +61,7 @@
     node: h-0005.tor1.incd.ca
     workspace: $parent_workspace
     builders:
-      - shell: DISPLAY=:0 BUILD_ID=gpii-express vagrant ci test --provider virtualbox
+      - shell: DISPLAY=:0 BUILD_ID=gpii-express vagrant ci test
     publishers:
       - email:
           recipients: ci@lists.gpii.net

--- a/jenkins_jobs/gpii-handlebars.yml
+++ b/jenkins_jobs/gpii-handlebars.yml
@@ -61,7 +61,7 @@
     node: h-0005.tor1.incd.ca
     workspace: $parent_workspace
     builders:
-      - shell: DISPLAY=:0 BUILD_ID=gpii-handlebars vagrant ci test --provider virtualbox
+      - shell: DISPLAY=:0 BUILD_ID=gpii-handlebars vagrant ci test
     publishers:
       - email:
           recipients: ci@lists.gpii.net

--- a/jenkins_jobs/gpii-json-schema.yml
+++ b/jenkins_jobs/gpii-json-schema.yml
@@ -61,7 +61,7 @@
     node: h-0005.tor1.incd.ca
     workspace: $parent_workspace
     builders:
-      - shell: DISPLAY=:0 BUILD_ID=gpii-json-schema vagrant ci test --provider virtualbox
+      - shell: DISPLAY=:0 BUILD_ID=gpii-json-schema vagrant ci test
     publishers:
       - email:
           recipients: ci@lists.gpii.net

--- a/jenkins_jobs/gpii-testem.yml
+++ b/jenkins_jobs/gpii-testem.yml
@@ -62,8 +62,6 @@
      - shell: DISPLAY=:0 vagrant ci help
 
 - job:
-=======
->>>>>>> upstream/master
     name: gpii-testem-create-vm
     description: 'Create a test VM.'
     node: h-0005.tor1.incd.ca
@@ -79,7 +77,7 @@
     node: h-0005.tor1.incd.ca
     workspace: $parent_workspace
     builders:
-      - shell: DISPLAY=:0 BUILD_ID=gpii-testem vagrant ci test --provider virtualbox
+      - shell: DISPLAY=:0 BUILD_ID=gpii-testem vagrant ci test
     publishers:
       - email:
           recipients: ci@lists.gpii.net


### PR DESCRIPTION
Continuing to work on [GPII-3842](https://issues.gpii.net/browse/GPII-3842), now tweaking later build stages.

cc: @amatas 