### PR TITLE
GPII-4129: Fixed indentation in update gpii-webdriver config.

### DIFF
--- a/jenkins_jobs/gpii-webdriver.yml
+++ b/jenkins_jobs/gpii-webdriver.yml
@@ -7,7 +7,7 @@
     properties:
       # Required by the GitHub PR builder plugin.
       - github:
-      url: "https://github.com/GPII/gpii-webdriver/"
+          url: "https://github.com/GPII/gpii-webdriver/"
     triggers:
       - gh-pr-builder
     scm:


### PR DESCRIPTION
Third attempt, [the previous attempt](https://github.com/GPII/ci-service/pull/65) failed because of poor indenting.  This pass was linted using `yamllint`.

cc: @amb26 