### PR TITLE
GPII-4177: Specify which VM (linux) should be halted/destroyed after gpii-couchdb-test-harness tests run.

### DIFF
--- a/jenkins_jobs/gpii-couchdb-test-harness.yml
+++ b/jenkins_jobs/gpii-couchdb-test-harness.yml
@@ -86,4 +86,4 @@
     node: h-0005.tor1.incd.ca
     workspace: $parent_workspace
     builders:
-      - shell: vagrant halt -f && sleep 5 && vagrant destroy -f
+      - shell: vagrant halt -f linux && sleep 5 && vagrant destroy -f linux


### PR DESCRIPTION
See [GPII-4177](https://issues.gpii.net/browse/GPII-4177) for details.

cc: @amb26 