### PR TITLE
GPII-4444: Added the fail policy to the timeout wrapper

### DIFF
--- a/jenkins_jobs/windows.yml
+++ b/jenkins_jobs/windows.yml
@@ -86,6 +86,7 @@
     wrappers:
       - timeout:
           timeout: 90
+          fail: true
 
 - job:
     name: windows-acceptance-tests
@@ -100,6 +101,7 @@
     wrappers:
       - timeout:
           timeout: 90
+          fail: true
 
 - job:
     name: windows-delete-vm


### PR DESCRIPTION
See https://issues.gpii.net/browse/GPII-4444
Could the problem be that the timeout wrapper is missing the fail policy?